### PR TITLE
Update map to change layers based off selected member

### DIFF
--- a/lametro/templates/board_members/_map.html
+++ b/lametro/templates/board_members/_map.html
@@ -368,21 +368,6 @@
         });
     }
 
-    function activateButton(button) {
-        $('#' + button + 'Toggle').prepend('<i class="fa fa-check" aria-hidden="true"></i>');
-        $('#' + button + 'Toggle').addClass('active');
-
-        // Remove the 'active' class from unused layer buttons
-        let layersArr = ['district', 'section', 'city'];
-        layersArr = jQuery.grep(layersArr, function(value) {
-            return value != button;
-        });
-
-        layersArr.forEach(element => {
-            $('#' + element + 'Toggle').removeClass('active');
-        });
-    }
-
     function changeLayersDistrict() {
         map.addLayer(districts);
         map.removeLayer(sectors);
@@ -443,18 +428,17 @@
             removeCheck();
         });
 
-        // TODO: get each person's section to highlight correctly on the map
         $('#council-members tbody tr').on('mouseover', function() {
-            removeCheck();
+            $('#toggleControls .fa.fa-check').remove();
 
             if ($(this).is(':contains("District appointee")')) {
-                activateButton('district');
+                $('#districtToggle').prepend('<i class="fa fa-check" aria-hidden="true"></i>')
                 changeLayersDistrict();
             } else if ($(this).is(':contains("Sector appointee")')) {
-                activateButton('sector');
+                $('#sectorToggle').prepend('<i class="fa fa-check" aria-hidden="true"></i>')
                 changeLayersSector();
             } else if ($(this).is(':contains("Los Angeles")')) {
-                activateButton('city');
+                $('#cityToggle').prepend('<i class="fa fa-check" aria-hidden="true"></i>')
                 changeLayersCity();
             };
         });

--- a/lametro/templates/board_members/_map.html
+++ b/lametro/templates/board_members/_map.html
@@ -362,30 +362,34 @@
     }
 
     function removeCheck() {
-        $('div#toggleControls .active').html( function(){
-            var buttonLabel = $('div#toggleControls .active').html();
-            return buttonLabel.replace('<i class="fa fa-check" aria-hidden="true"></i>', '');
-        });
+        $('#toggleControls .fa.fa-check').remove();
     }
 
     function changeLayers(layer) {
         $('#' + layer + 'Toggle').prepend('<i class="fa fa-check" aria-hidden="true"></i>')
+        $('#' + layer + 'Toggle').addClass('active')
 
         switch (layer) {
             case 'district':
                 map.addLayer(districts);
                 map.removeLayer(sectors);
                 map.removeLayer(los_angeles_city);
+                $('#sectorToggle').removeClass('active');
+                $('#cityToggle').removeClass('active');
                 break;
             case 'sector':
                 map.addLayer(sectors);
                 map.removeLayer(districts);
                 map.removeLayer(los_angeles_city);
+                $('#districtToggle').removeClass('active');
+                $('#cityToggle').removeClass('active');
                 break;
             case 'city':
                 map.addLayer(los_angeles_city);
                 map.removeLayer(districts);
                 map.removeLayer(sectors);
+                $('#districtToggle').removeClass('active');
+                $('#sectorToggle').removeClass('active');
                 break;
         }
     }
@@ -415,25 +419,22 @@
         });
 
         $('#districtToggle').on('click', function() {
-            changeLayersDistrict();
-            $(this).prepend('<i class="fa fa-check" aria-hidden="true"></i>')
             removeCheck();
+            changeLayers('district');
         });
 
         $('#sectorToggle').on('click', function() {
-            changeLayersSector();
-            $(this).prepend('<i class="fa fa-check" aria-hidden="true"></i>')
             removeCheck();
+            changeLayers('sector');
         });
 
         $('#cityToggle').on('click', function() {
-            changeLayersCity();
-            $(this).prepend('<i class="fa fa-check" aria-hidden="true"></i>')
             removeCheck();
+            changeLayers('city');
         });
 
-        $('#council-members tbody tr').on('click', function() {
-            $('#toggleControls .fa.fa-check').remove();
+        $('#council-members tbody tr').on('click', function(e) {
+            removeCheck();
 
             if ($(this).is(':contains("District appointee")')) {
                 changeLayers('district');

--- a/lametro/templates/board_members/_map.html
+++ b/lametro/templates/board_members/_map.html
@@ -368,22 +368,26 @@
         });
     }
 
-    function changeLayersDistrict() {
-        map.addLayer(districts);
-        map.removeLayer(sectors);
-        map.removeLayer(los_angeles_city);
-    }
+    function changeLayers(layer) {
+        $('#' + layer + 'Toggle').prepend('<i class="fa fa-check" aria-hidden="true"></i>')
 
-    function changeLayersSector() {
-        map.addLayer(sectors);
-        map.removeLayer(districts);
-        map.removeLayer(los_angeles_city);
-    }
-
-    function changeLayersCity() {
-        map.addLayer(los_angeles_city);
-        map.removeLayer(districts);
-        map.removeLayer(sectors);
+        switch (layer) {
+            case 'district':
+                map.addLayer(districts);
+                map.removeLayer(sectors);
+                map.removeLayer(los_angeles_city);
+                break;
+            case 'sector':
+                map.addLayer(sectors);
+                map.removeLayer(districts);
+                map.removeLayer(los_angeles_city);
+                break;
+            case 'city':
+                map.addLayer(los_angeles_city);
+                map.removeLayer(districts);
+                map.removeLayer(sectors);
+                break;
+        }
     }
 
     $(function() {
@@ -428,18 +432,15 @@
             removeCheck();
         });
 
-        $('#council-members tbody tr').on('mouseover', function() {
+        $('#council-members tbody tr').on('click', function() {
             $('#toggleControls .fa.fa-check').remove();
 
             if ($(this).is(':contains("District appointee")')) {
-                $('#districtToggle').prepend('<i class="fa fa-check" aria-hidden="true"></i>')
-                changeLayersDistrict();
+                changeLayers('district');
             } else if ($(this).is(':contains("Sector appointee")')) {
-                $('#sectorToggle').prepend('<i class="fa fa-check" aria-hidden="true"></i>')
-                changeLayersSector();
+                changeLayers('sector');
             } else if ($(this).is(':contains("Los Angeles")')) {
-                $('#cityToggle').prepend('<i class="fa fa-check" aria-hidden="true"></i>')
-                changeLayersCity();
+                changeLayers('city');
             };
         });
 

--- a/lametro/templates/board_members/_map.html
+++ b/lametro/templates/board_members/_map.html
@@ -368,6 +368,29 @@
         });
     }
 
+    function activateButton(button) {
+        $('#' + button + 'Toggle').prepend('<i class="fa fa-check" aria-hidden="true"></i>')
+        $('#' + button + 'Toggle').addClass('active')
+    }
+
+    function changeLayersDistrict() {
+        map.addLayer(districts);
+        map.removeLayer(sectors);
+        map.removeLayer(los_angeles_city);
+    }
+
+    function changeLayersSector() {
+        map.addLayer(sectors);
+        map.removeLayer(districts);
+        map.removeLayer(los_angeles_city);
+    }
+
+    function changeLayersCity() {
+        map.addLayer(los_angeles_city);
+        map.removeLayer(districts);
+        map.removeLayer(sectors);
+    }
+
     $(function() {
         initialize();
 
@@ -393,27 +416,38 @@
         });
 
         $('#districtToggle').on('click', function() {
-            map.addLayer(districts);
-            map.removeLayer(sectors);
-            map.removeLayer(los_angeles_city);
+            changeLayersDistrict();
             $(this).prepend('<i class="fa fa-check" aria-hidden="true"></i>')
             removeCheck();
         });
 
         $('#sectorToggle').on('click', function() {
-            map.addLayer(sectors);
-            map.removeLayer(districts);
-            map.removeLayer(los_angeles_city);
+            changeLayersSector();
             $(this).prepend('<i class="fa fa-check" aria-hidden="true"></i>')
             removeCheck();
         });
 
         $('#cityToggle').on('click', function() {
-            map.addLayer(los_angeles_city);
-            map.removeLayer(districts);
-            map.removeLayer(sectors);
+            changeLayersCity();
             $(this).prepend('<i class="fa fa-check" aria-hidden="true"></i>')
             removeCheck();
+        });
+
+        // TODO: get each person's section to highlight correctly on the map
+        $('#council-members tbody tr').on('mouseover', function(e) {
+            removeCheck();
+            $('#toggleControls label').removeClass('active');
+
+            if ($(this).is(':contains("District appointee")')) {
+                activateButton('district');
+                changeLayersDistrict();
+            } else if ($(this).is(':contains("Sector appointee")')) {
+                activateButton('sector');
+                changeLayersSector();
+            } else if ($(this).is(':contains("Los Angeles")')) {
+                activateButton('city');
+                changeLayersCity();
+            };
         });
 
     });

--- a/lametro/templates/board_members/_map.html
+++ b/lametro/templates/board_members/_map.html
@@ -369,8 +369,18 @@
     }
 
     function activateButton(button) {
-        $('#' + button + 'Toggle').prepend('<i class="fa fa-check" aria-hidden="true"></i>')
-        $('#' + button + 'Toggle').addClass('active')
+        $('#' + button + 'Toggle').prepend('<i class="fa fa-check" aria-hidden="true"></i>');
+        $('#' + button + 'Toggle').addClass('active');
+
+        // Remove the 'active' class from unused layer buttons
+        let layersArr = ['district', 'section', 'city'];
+        layersArr = jQuery.grep(layersArr, function(value) {
+            return value != button;
+        });
+
+        layersArr.forEach(element => {
+            $('#' + element + 'Toggle').removeClass('active');
+        });
     }
 
     function changeLayersDistrict() {
@@ -434,9 +444,8 @@
         });
 
         // TODO: get each person's section to highlight correctly on the map
-        $('#council-members tbody tr').on('mouseover', function(e) {
+        $('#council-members tbody tr').on('mouseover', function() {
             removeCheck();
-            $('#toggleControls label').removeClass('active');
 
             if ($(this).is(':contains("District appointee")')) {
                 activateButton('district');

--- a/lametro/templates/board_members/board_members.html
+++ b/lametro/templates/board_members/board_members.html
@@ -194,6 +194,14 @@
         $('tbody tr').on( 'mouseover', function () {
             $('tr').css('background-color', 'inherit')
             $(this).css('background-color', '#eee');
+            // TODO: maybe make this is switch case?
+            if ($(this).is(':contains("District appointee")')) {
+                activateButton('district');
+            } else if ($(this).is(':contains("Sector appointee")')) {
+                activateButton('sector');
+            } else if ($(this).is(':contains("Los Angeles")')) {
+                activateButton('city');
+            };
             activeToggle = $('#toggleControls').find('.active').attr('id');
             memberNameSlug = $(this).attr('data')
             hoverOnRow(this.id, activeToggle, memberNameSlug);
@@ -204,6 +212,11 @@
             activeToggle = $('#toggleControls').find('.active').attr('id');
             hoverOffRow(this.id, activeToggle);
         } )
+
+        function activateButton(button) {
+            $('#districtToggle, #sectorToggle, #cityToggle').removeClass('active');
+            $('#' + button + 'Toggle').addClass('active');
+        }
 
         function hoverOffRow(select_id, active_id){
             var controlView = $("#toggleControls").is(":hidden");

--- a/lametro/templates/board_members/board_members.html
+++ b/lametro/templates/board_members/board_members.html
@@ -194,15 +194,7 @@
         $('tbody tr').on( 'mouseover', function () {
             $('tr').css('background-color', 'inherit')
             $(this).css('background-color', '#eee');
-
-            if ($(this).is(':contains("District appointee")')) {
-                activeToggle = activateButton('district');
-            } else if ($(this).is(':contains("Sector appointee")')) {
-                activeToggle = activateButton('sector');
-            } else if ($(this).is(':contains("Los Angeles")')) {
-                activeToggle = activateButton('city');
-            };
-
+            activeToggle = $('#toggleControls').find('.active').attr('id');
             memberNameSlug = $(this).attr('data')
             hoverOnRow(this.id, activeToggle, memberNameSlug);
         } );
@@ -212,12 +204,6 @@
             activeToggle = $('#toggleControls').find('.active').attr('id');
             hoverOffRow(this.id, activeToggle);
         } )
-
-        function activateButton(button) {
-            $('#districtToggle, #sectorToggle, #cityToggle').removeClass('active');
-            $('#' + button + 'Toggle').addClass('active');
-            return (button + 'Toggle')
-        }
 
         function hoverOffRow(select_id, active_id){
             var controlView = $("#toggleControls").is(":hidden");

--- a/lametro/templates/board_members/board_members.html
+++ b/lametro/templates/board_members/board_members.html
@@ -194,15 +194,15 @@
         $('tbody tr').on( 'mouseover', function () {
             $('tr').css('background-color', 'inherit')
             $(this).css('background-color', '#eee');
-            // TODO: maybe make this is switch case?
+
             if ($(this).is(':contains("District appointee")')) {
-                activateButton('district');
+                activeToggle = activateButton('district');
             } else if ($(this).is(':contains("Sector appointee")')) {
-                activateButton('sector');
+                activeToggle = activateButton('sector');
             } else if ($(this).is(':contains("Los Angeles")')) {
-                activateButton('city');
+                activeToggle = activateButton('city');
             };
-            activeToggle = $('#toggleControls').find('.active').attr('id');
+
             memberNameSlug = $(this).attr('data')
             hoverOnRow(this.id, activeToggle, memberNameSlug);
         } );
@@ -216,6 +216,7 @@
         function activateButton(button) {
             $('#districtToggle, #sectorToggle, #cityToggle').removeClass('active');
             $('#' + button + 'Toggle').addClass('active');
+            return (button + 'Toggle')
         }
 
         function hoverOffRow(select_id, active_id){


### PR DESCRIPTION
## Overview

This PR allows users to change map layers based off clicking board members in the adjacent table.

Closes #482 

### Notes

At time of writing, the layers change and mouseover still works, with one caveat. When first clicking a member to change the map layers, that member's section does not highlight right away. You need to continue hovering over them to get the highlight to start working for that layer. 

I think this is because a `tableover` event that is responsible for highlighting that member's section doesn't go off until the appropriate layer is active. I'm not sure how to go about tackling this at the moment.

## Testing Instructions

 * In the board members page, click through different members in order to change map layers
