### PR TITLE
Exclude test meetings

### DIFF
--- a/lametro/templates/events/events.html
+++ b/lametro/templates/events/events.html
@@ -94,6 +94,24 @@
                 <a href="" class="btn btn-salmon" id="more-events"><i class="fa fa-fw fa-chevron-down"></i>Show all past meetings</a>
                 <a href="" class="btn btn-salmon" id="fewer-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer past meetings</a>
 
+            {% elif past_events %}
+                <h2 style="margin-top: 40px;"><span>Past {{ CITY_VOCAB.EVENTS }}</span>
+                <br class="non-desktop-only"/>
+                <small><a href="rss/" title="RSS feed for Upcoming and Recent Events"><i class="fa fa-rss-square" aria-hidden="true"></i></a></small>
+                </h2><br class="non-mobile-only"/>
+
+                <div class='row'>
+                    <div class='col-sm-8' id='events_message'></div>
+                </div>
+
+                {% for date, event_list in past_events %}
+                    <div class='event-listing'>
+                    {% include "events/_past_event_day.html" %}
+                    </div>
+                {% endfor %}
+
+                <a href="" class="btn btn-salmon" id="more-events"><i class="fa fa-fw fa-chevron-down"></i>Show all past meetings</a>
+                <a href="" class="btn btn-salmon" id="fewer-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer past meetings</a>
             {% elif select_events %}
                 <h2><span>{{ CITY_VOCAB.EVENTS }} from {{ start_date }} to {{ end_date }}</span>
                 <br class="non-desktop-only"/>

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -323,8 +323,8 @@ class LAMetroEventsView(EventsView):
             event__extras__approved_minutes=True, note__icontains="minutes"
         )
 
-        # A base queryset for objects with media
-        media_events = LAMetroEvent.objects.with_media()
+        # A base queryset for non-test objects with media
+        media_events = LAMetroEvent.objects.with_media().exclude(name__icontains="test")
 
         # If yes...
         if start_date_str and end_date_str:

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -323,6 +323,9 @@ class LAMetroEventsView(EventsView):
             event__extras__approved_minutes=True, note__icontains="minutes"
         )
 
+        # A base queryset for objects with media
+        media_events = LAMetroEvent.objects.with_media()
+
         # If yes...
         if start_date_str and end_date_str:
             context["start_date"] = start_date_str
@@ -331,8 +334,7 @@ class LAMetroEventsView(EventsView):
             end_date_time = parser.parse(end_date_str)
 
             select_events = (
-                LAMetroEvent.objects.with_media()
-                .filter(start_time__gt=start_date_time)
+                media_events.filter(start_time__gt=start_date_time)
                 .filter(start_time__lt=end_date_time)
                 .order_by("start_time")
             )
@@ -350,7 +352,7 @@ class LAMetroEventsView(EventsView):
 
         # If all meetings
         elif self.request.GET.get("show"):
-            all_events = LAMetroEvent.objects.with_media().order_by("-start_time")
+            all_events = media_events.order_by("-start_time")
             org_all_events = []
 
             for event_date, events in itertools.groupby(all_events, key=day_grouper):
@@ -361,10 +363,8 @@ class LAMetroEventsView(EventsView):
         # If no...
         else:
             # Upcoming events
-            future_events = (
-                LAMetroEvent.objects.with_media()
-                .filter(start_time__gt=timezone.now())
-                .order_by("start_time")
+            future_events = media_events.filter(start_time__gt=timezone.now()).order_by(
+                "start_time"
             )
             org_future_events = []
 
@@ -375,10 +375,8 @@ class LAMetroEventsView(EventsView):
             context["future_events"] = org_future_events
 
             # Past events
-            past_events = (
-                LAMetroEvent.objects.with_media()
-                .filter(start_time__lt=timezone.now())
-                .order_by("-start_time")
+            past_events = media_events.filter(start_time__lt=timezone.now()).order_by(
+                "-start_time"
             )
 
             past_events = past_events.prefetch_related(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -695,14 +695,14 @@ def test_live_comment_details_display_as_expected(
 
 @pytest.mark.django_db
 def test_exclude_events_with_test_in_name(event, client):
-    # TODO: make sure that we can correctly search for events on the page
-    event_regular = event.build()
+    """
+    Check that events with 'test' in the name are not getting displayed, but that regular events are still present.
+    """
+    event_test = event.build(name="Test - Live Regular Meeting Test")
+    event_regular = event.build(name="Live Regular Meeting", id=101)
 
-    url = reverse("lametro:events")
+    url = reverse("lametro:event")
     response = client.get(url)
-    print(response.content.decode("utf-8"))
 
+    assert event_test.name not in response.content.decode("utf-8")
     assert event_regular.name in response.content.decode("utf-8")
-    # event_test = event.build(name="Test - Live Regular Meeting Test")
-    # event_test.save()
-    # assert event_test.name not in response.content.decode("utf-8")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -691,3 +691,18 @@ def test_live_comment_details_display_as_expected(
 
     for line in live_comment_signature:
         assert (line in response_content) == expected_live_comment_value
+
+
+@pytest.mark.django_db
+def test_exclude_events_with_test_in_name(event, client):
+    # TODO: make sure that we can correctly search for events on the page
+    event_regular = event.build()
+
+    url = reverse("lametro:events")
+    response = client.get(url)
+    print(response.content.decode("utf-8"))
+
+    assert event_regular.name in response.content.decode("utf-8")
+    # event_test = event.build(name="Test - Live Regular Meeting Test")
+    # event_test.save()
+    # assert event_test.name not in response.content.decode("utf-8")


### PR DESCRIPTION
## Overview

Test meetings were being shown on the events calendar when they weren't supposed to. This PR excludes those test meetings, and writes a new test that both confirms this and ensures that regular meetings are still being shown. 

It also fixes a logic error in `events.html` that prevents past events from showing up if there are no future events.

Closes #942 

## Testing Instructions

- Run `pytest tests/test_events.py -v -k 'test_exclude_events_with_test_in_name'` and confirm that it passes.
