### PR TITLE
Clear cache on headshot upload

### DIFF
--- a/lametro/views.py
+++ b/lametro/views.py
@@ -650,7 +650,7 @@ class LAPersonDetailView(PersonDetailView):
                     self.get_context_data(form=form, headshot_error=error)
                 )
 
-            # cache.clear()
+            cache.clear()
             person.image = self.get_file_url(request, file_obj)
             person.save()
             return HttpResponseRedirect(self.request.path_info)

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -32,6 +32,7 @@ from django.http import (
 )
 from django.core import management
 from django.core.serializers import serialize
+from django.core.cache import cache
 
 from councilmatic_core.views import (
     IndexView,
@@ -649,6 +650,7 @@ class LAPersonDetailView(PersonDetailView):
                     self.get_context_data(form=form, headshot_error=error)
                 )
 
+            # cache.clear()
             person.image = self.get_file_url(request, file_obj)
             person.save()
             return HttpResponseRedirect(self.request.path_info)


### PR DESCRIPTION
## Overview

This clears the cache when a board member's headshot is updated.

Connects #954

## Testing Instructions

 * Upload a headshot for a newly added board member
 * Make sure that the headshot is updated on the:
   * board members listing page
   * board member detail page
