### PR TITLE
Allow streaming meetings to be current

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -639,9 +639,14 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
         six_hours_ago = cls._time_ago(hours=6)
         five_minutes_from_now = cls._time_from_now(minutes=5)
 
+        was_cancelled = Q(status="cancelled")
+        has_passed = Q(broadcast__observed=True) & ~Q(
+            pk__in=cls._streaming_meeting().values_list("pk")
+        )
+
         return cls.objects.filter(
             start_time__gte=six_hours_ago, start_time__lte=five_minutes_from_now
-        ).exclude(Q(status="cancelled") | Q(broadcast__observed=True))
+        ).exclude(was_cancelled | has_passed)
 
     @classmethod
     def _streaming_meeting(cls):


### PR DESCRIPTION
## Overview

See title. Meeting broadcasts are created when a meeting goes live, so we were prematurely excluding those events from the current meeting query.

Cc @xmedr – I didn't catch this! 

Connects #925 

### Demo

Deployed to staging.

![Screenshot 2023-04-19 at 1 22 33 PM](https://user-images.githubusercontent.com/12176173/233165748-7528c27b-6955-4e59-bc06-b31abac86dff.png)

## Testing Instructions

 * Deployed to staging to test.