### PR TITLE
Fix typo causing longstanding Sentry error, handles #924

### DIFF
--- a/lametro/templates/events/events.html
+++ b/lametro/templates/events/events.html
@@ -137,7 +137,7 @@
                 </div>
 
                 {% for date, event_list in all_events %}
-                    {% include "events_/_past_event_day.html" %}
+                    {% include "events/_past_event_day.html" %}
                 {% endfor %}
             {% else %}
                 <div class='row'>


### PR DESCRIPTION
## Overview

See title.

Connects #924

## Testing Instructions

 * Run the app locally, and view localhost:8001/events/?view=all – confirm the page loads without error.
