### PR TITLE
Only render facets once

### DIFF
--- a/lametro/templates/search/_search_filter.html
+++ b/lametro/templates/search/_search_filter.html
@@ -23,11 +23,11 @@
         </div>
         <div class="panel-body {% if facet_name in selected_facets %}panel-show{% endif %} collapse" id="filter-{{facet_name}}">
             <ul class="search-facet-list">
-            {% if facet_name in 'topics,lines_and_ways,phase,bill_type,project,metro_location,geo_admin_location,significant_date,motion_by,plan_program_policy' %}
+            {% if facet_name != 'sponsorships' %}
 
                 {% include 'search/_ordered_search_filter_items.html' %}
 
-            {% elif facet_name == 'sponsorships' %}
+            {% else %}
 
                 {% if facets.fields.legislative_session|length > 1 %}
 
@@ -71,14 +71,6 @@
 
                     {% endfor %}
                 {% endif %}
-
-            {% else %}
-
-                {% for name, count in item_list %}
-                    {% if count %}
-                        {% include 'search/_ordered_search_filter_items.html' %}
-                    {% endif %}
-                {% endfor %}
 
             {% endif %}
             </ul>


### PR DESCRIPTION
## Overview

I'm really not sure what changed, but my suspicion is some part of the upgrade altered how we fetch or render facets in a way that caused them to be duplicated. This PR resolves that issue.

Connects #950 

Fixed in concert with @xmedr! 

## Testing Instructions

Will deploy to the staging site.

 * View the search page and confirm fiscal year and status facets are only rendered once.
