### PR TITLE
Don't filter autocomplete suggestions by available subjects

### DIFF
--- a/smartlogic/views.py
+++ b/smartlogic/views.py
@@ -15,7 +15,7 @@ from smartlogic.exceptions import (
 
 
 class SmartLogicAPI(ListView):
-    ALLOWED_PARAMETERS = {"stop_cm_after_stage", "maxResultCount", "FILTER=AT"}
+    ALLOWED_PARAMETERS = {"stop_cm_after_stage", "maxResultCount", "FILTER"}
 
     def setup(self, request, *args, **kwargs):
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -120,6 +120,9 @@ def test_lametro_smartlogic_api_relate(client, metro_subject, mocker):
     assert response["status_code"] == 200
     assert len(response["subjects"]) == 1
 
+    # Test that the result is our existent subject
+    assert response["subjects"][0]["guid"] == b_line.guid
+
 
 @pytest.mark.django_db
 def test_fetch_object_counts(client, bill, event):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,16 +95,13 @@ def test_lametro_smartlogic_api_suggest(client, metro_subject, mocker):
     response = client.get(lametro_ses_endpoint).json()
 
     assert response["status_code"] == 200
-    assert len(response["subjects"]) == 2
+    assert len(response["subjects"]) == 10
 
     # Test that the red line is the first result
     assert response["subjects"][0]["guid"] == red_line.guid
 
     # Test that the synonym matching the search term was appended to the subject name
     assert response["subjects"][0]["display_name"] == "Metro Red Line (Red Line)"
-
-    # Test that the second result is rail operations
-    assert response["subjects"][1]["guid"] == rail_operations.guid
 
 
 def test_lametro_smartlogic_api_relate(client, metro_subject, mocker):
@@ -121,10 +118,7 @@ def test_lametro_smartlogic_api_relate(client, metro_subject, mocker):
     response = client.get(lametro_ses_endpoint).json()
 
     assert response["status_code"] == 200
-    assert len(response["subjects"]) == 1
-
-    # Test that the result is our existent subject
-    assert response["subjects"][0]["guid"] == b_line.guid
+    assert len(response["subjects"]) == 10
 
 
 @pytest.mark.django_db

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,7 +118,7 @@ def test_lametro_smartlogic_api_relate(client, metro_subject, mocker):
     response = client.get(lametro_ses_endpoint).json()
 
     assert response["status_code"] == 200
-    assert len(response["subjects"]) == 10
+    assert len(response["subjects"]) == 1
 
 
 @pytest.mark.django_db

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -83,11 +83,6 @@ def test_lametro_smartlogic_api_suggest(client, metro_subject, mocker):
         guid="1031d836-2d8b-4c20-b3c1-1487f0d503e6",
     )
 
-    rail_operations = metro_subject.build(
-        name="Rail Operations - Red Line (Project)",
-        guid="b53296db-4ac2-455d-9942-2bfba6f1c8bf",
-    )
-
     lametro_ses_endpoint = reverse(
         "lametro_ses_endpoint", kwargs={"term": "red line", "action": "suggest"}
     )


### PR DESCRIPTION
## Overview

This PR tweaks the previously approved SmartLogic refactor so that autocomplete suggestions are not filtered by available terms, which is the current behavior of the site.

## Testing Instructions

 * Confirm CI passes!
 * Confirm the code changes look good.