### PR TITLE
Handle read timeout on external requests

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -664,7 +664,7 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
             running_events = requests.get(
                 "http://metro.granicus.com/running_events.php", timeout=5
             )
-        except requests.exceptions.ConnectTimeout:
+        except (requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout):
             return cls.objects.none()
 
         if running_events.status_code == 200:

--- a/smartlogic/client.py
+++ b/smartlogic/client.py
@@ -12,7 +12,7 @@ except AssertionError:
 import json
 
 import requests
-from requests.exceptions import HTTPError, ConnectTimeout
+from requests.exceptions import HTTPError, ConnectTimeout, ReadTimeout
 
 from smartlogic.exceptions import (
     RequestFailed,
@@ -47,7 +47,7 @@ class SmartLogic(object):
 
         try:
             response = getattr(requests, method)(url, timeout=5, **requests_kwargs)
-        except (HTTPError, ConnectTimeout):
+        except (HTTPError, ConnectTimeout, ReadTimeout):
             raise
 
         if response.status_code == 403:

--- a/smartlogic/views.py
+++ b/smartlogic/views.py
@@ -3,7 +3,7 @@ import json
 from django.conf import settings
 from django.http import JsonResponse
 from django.views.generic import ListView
-from requests.exceptions import HTTPError, ConnectTimeout
+from requests.exceptions import HTTPError, ConnectTimeout, ReadTimeout
 
 from smartlogic.client import SmartLogic
 from smartlogic.exceptions import (
@@ -37,7 +37,7 @@ class SmartLogicAPI(ListView):
             reason = e.response.reason
             status_code = e.response.status_code
 
-        except ConnectTimeout:
+        except (ConnectTimeout, ReadTimeout):
             message = "Could not reach SmartLogic"
             reason = "Read timeout"
             status_code = 504


### PR DESCRIPTION
## Overview

See title. This expands graceful error handling when we can't reach Legistar and/or SmartLogic. Connects #699.

## Testing Instructions

Tested locally.
