### PR TITLE
Sort board report topics alphabetically

### DIFF
--- a/lametro/templates/legislation.html
+++ b/lametro/templates/legislation.html
@@ -192,7 +192,7 @@
                     {% for category, topics in topics_list %}
                         <h4>{{ category }}</h4>
                         <ul>
-                        {% for topic in topics %}
+                        {% for topic in topics|sort_topics %}
                             {% with topic.classification|add:":"|add:topic.name as tag_facet %}
                             <li>
                                 <a href="{% search_with_querystring request selected_facets=tag_facet %}">

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -309,3 +309,10 @@ def group_by_classification(queryset):
         lambda item: item.get_classification_display(),
     ):
         yield group, list(members)
+
+
+@register.filter
+def sort_topics(topics):
+    """Sorts a board report's topics alphabetically."""
+
+    return sorted(topics, key=lambda t: t.name)


### PR DESCRIPTION
## Overview

See title.

Closes #983 

### Demo

![FireShot Capture 021 - 2020-0829 - WESTSIDE PURPLE LINE EXTENSION SECTION 3 PROJECT - Metro _ - localhost](https://github.com/Metro-Records/la-metro-councilmatic/assets/36973363/20e80f7f-ec74-4b75-9e0d-a91d9fc26f3b)

## Testing Instructions

 * Navigate to a board report
 * Verify that board report topics are listed alphabetically