### PR TITLE
Fix Google translate bar position

### DIFF
--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -119,6 +119,22 @@
                 'google_translate_element');
         }
 
+		// Make sure the Google Translate toolbar doesn't block the navbar
+		const navBar = document.querySelector("nav"),
+		  languageSelector = document.querySelector("#google_translate_element")
+
+		languageSelector.addEventListener("change", (e) => {
+			// Make room for the translate bar
+			navBar.style.top = "40px";
+
+			const translateBar = document.querySelector(".skiptranslate iframe"),
+			  translateBarDoc = translateBar.contentWindow.document,
+			  translateBarClose = translateBarDoc.querySelector("a[title='Close']")
+
+			  // Move navbar back up when translate bar is closed
+			  translateBarClose.addEventListener("click", (e) => navBar.style.top = "0px")
+		  })
+
         function listenForSearch() {
             $('form#search-form').submit(function validateFormSubmission(e) {
                 e.preventDefault();


### PR DESCRIPTION
## Overview

See title.

Connects #991 

### Demo

![FireShot Capture 025 - ಮುಖಪುಟ - ಮೆಟ್ರೋ ಬೋರ್ಡ್ - localhost](https://github.com/Metro-Records/la-metro-councilmatic/assets/36973363/625ec5f4-3ec9-4674-8d35-87ec6b5c8b15)

## Testing Instructions

 * Navigate to the home page
 * Select a language to translate the page to
 * Verify that the google translate bar doesn't block the navbar