### PR TITLE
Refactor person detail and align logout btn w/other nav items

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -350,6 +350,10 @@ hr .events-line {
     .current-meeting-img {
         max-width: 75%;
     }
+
+    #person-detail-headshot {
+        max-height: none;
+    }
 }
 
 @media only screen and (max-width : 415px) {
@@ -378,6 +382,15 @@ hr .events-line {
         padding-right: 15px;
     }
 
+    .nav-pills > li > a {
+        font-size: 16px;
+        padding-left: 0px;
+        padding-right: 0px;
+    }
+
+    .nav-pills {
+        justify-content: space-between;
+    }
 }
 
 @media only screen and (max-width : 767px) {
@@ -517,7 +530,7 @@ hr .events-line {
     padding-left: 10px !important;
 }
 
-.nav-item:hover, .nav-item:active, .nav-item:focus {
+.navbar-nav>.nav-item:hover, .navbar-nav>.nav-item:active, .navbar-nav>.nav-item:focus {
     background-color: #eeeeee;
 }
 
@@ -602,4 +615,26 @@ small.rss {
 
 .badge-facet.ms-auto {
     height: fit-content;
+}
+
+.fw-normal {
+    font-weight: normal;
+}
+
+.nav-pills .nav-link.active {
+    background: none;
+    color: #3D8A8E;
+    border-bottom: 8px solid #3D8A8E;
+}
+
+.nav-pills .nav-link:focus {
+    color: #114f52;
+}
+
+#map-detail {
+    width: 100%;
+}
+
+input[name="headshot"] {
+    width: 100%;
 }

--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -70,13 +70,15 @@
                   </ul>
                 </li>
                 {% nocache %}
-                    <li>
-                        {% if user.is_authenticated %}
+                    {% if user.is_authenticated %}
+                        <li class="nav-item pt-4">
                             <a href="{% url 'metro_logout' %}"><i class="fa fa-sign-out" aria-hidden="true"></i> Logout</a>
-                        {% else %}
+                        </li>
+                    {% else %}
+                        <li>
                             <div id="google_translate_element"></div>
-                        {% endif %}
-                    </li>
+                        </li>
+                    {% endif %}
                 {% endnocache %}
               </ul>
             </div>

--- a/lametro/templates/base_with_margins.html
+++ b/lametro/templates/base_with_margins.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block full_content %}
-  	<div class="container-fluid">
+  	<div class="container-fluid mt-5">
     	<div class='col-12 px-4'>
       		{% block content %}
       		{% endblock %}

--- a/lametro/templates/person/_legislation_item.html
+++ b/lametro/templates/person/_legislation_item.html
@@ -1,46 +1,46 @@
 {% load extras %}
 
+<hr aria-hidden="true">
+
 <p>
     <a class="small" href="/board-report/{{ legislation.slug }}/">{{ legislation.friendly_name }}</a>
     {{ legislation.inferred_status | inferred_status_label | safe }}
 </p>
 
 <div class="row">
-    <div class="col-xs-11">
-
+    <div class="col-10 col-sm-11">
         <p>
             {{ legislation.listing_description | short_blurb }}
         </p>
-
     </div>
-    <div class='col-xs-1 no-pad-mobile'>
-        <div>
-            <a class='btn-bill-detail' href='/board-report/{{ legislation.slug }}/'>
-                <i class="fa fa-fw fa-chevron-right"></i>
-            </a>
-        </div>
+
+    <div class="col-2 col-sm-1">
+        <a class='btn-bill-detail' href='/board-report/{{ legislation.slug }}/'>
+            <i class="fa fa-fw fa-chevron-right"></i>
+        </a>
     </div>
 </div>
 
-<p>
-    <span class="small text-muted"><i class="fa fa-fw fa-calendar-o"></i> {{legislation.last_action_date|date:'n/d/Y'}} - {{legislation.current_action.description | remove_action_subj }}</span><br/>
+<div class="row">
+    <div class="col-10 col-sm-11">
+        <p class="small text-muted mb-0">
+            <i class="fa fa-fw fa-calendar-o" aria-hidden="true"></i> {{legislation.last_action_date|date:'n/d/Y'}} - {{legislation.current_action.description | remove_action_subj }}
+        </p>
 
-    {% if legislation.topics %}
-        <i class="fa fa-fw fa-tag"></i>
-        {% for tag in legislation.topics %}
-            <span class="badge badge-muted pseudo-topic-tag">
-                <a href='/search/?q=&selected_facets=topics_exact:{{ tag }}'>{{ tag }}</a>
-            </span>
-        {% endfor %}
-        <br/>
-    {% else %}
-        <i class="fa fa-fw fa-tag"></i>
-        {% for tag in legislation.pseudo_topics %}
-            <span class="badge badge-muted pseudo-topic-tag">
-                <a href='/search/?q={{request.GET.q}}&selected_facets=sponsorships_exact%3A{{ tag }}'>{{ tag | committee_topic_only }}</a>
-            </span>&nbsp;
-        {% endfor %}
-        <br/>
-    {% endif %}
-    <br/>
-</p>
+        {% if legislation.topics %}
+            <i class="fa fa-fw fa-tag" aria-hidden="true"></i>
+            {% for tag in legislation.topics %}
+                <span class="badge badge-muted pseudo-topic-tag">
+                    <a href='/search/?q=&selected_facets=topics_exact:{{ tag }}'>{{ tag }}</a>
+                </span>
+            {% endfor %}
+        {% else %}
+            <i class="fa fa-fw fa-tag" aria-hidden="true"></i>
+            {% for tag in legislation.pseudo_topics %}
+                <span class="badge badge-muted pseudo-topic-tag">
+                    <a href='/search/?q={{request.GET.q}}&selected_facets=sponsorships_exact%3A{{ tag }}'>{{ tag | committee_topic_only }}</a>
+                </span>
+            {% endfor %}
+        {% endif %}
+    </div>
+</div>

--- a/lametro/templates/person/_person_ceo.html
+++ b/lametro/templates/person/_person_ceo.html
@@ -1,24 +1,27 @@
 {% load extras %}
 {% load lametro_extras %}
 
-<div class="row-fluid">
-    <div class="col-sm-4">
+<div class="row">
+   <div class="col-md-4">
         <img src='{{person.headshot_url}}' alt='{{person.name}}' title='{{person.name}}' class='img-responsive img-thumbnail img-padded' id="person-detail-headshot" />
-        <p class="small">
-            {% if qualifying_post %}
-                <i class='fa fa-fw fa-briefcase'></i>
+
+        {% if qualifying_post %}
+            <p class="small mb-1">
+                <i class='fa fa-fw fa-briefcase' aria-hidden="true"></i>
                 {{ qualifying_post | appointment_label }}
-            {% endif %}
-        </p>
-        {% if person.headshot_source %}
-            <hr />
-            <p class='small'>
-                <i class='fa fa-fw fa-camera'></i> Credit: {{person.headshot_source}}
             </p>
         {% endif %}
-    </div>
-    <div class='col-sm-6'>
+
+        {% if person.headshot_source %}
+            <p class='small mb-1'>
+                <i class='fa fa-fw fa-camera' aria-hidden="true"></i>
+                Credit: {{person.headshot_source}}
+            </p>
+        {% endif %}
+   </div>
+
+   <div class="col-md-8 mt-3">
         <h3>About {{ ceo.name }}</h3>
         <p>{{ member_bio | safe }}</p>
-    </div>
+   </div>
 </div>

--- a/lametro/templates/person/partials/person_bio_form.html
+++ b/lametro/templates/person/partials/person_bio_form.html
@@ -1,12 +1,11 @@
 {% load extras %}
 {% load lametro_extras %}
 
-<form role="form" method="POST" enctype="multipart/form-data">
+<form class="mb-4" role="form" method="POST" enctype="multipart/form-data">
     {% csrf_token %}
 
     {% if bio_error %}
-        <br>
-        <p style="color: #eb6864;">*{{bio_error}}</p>
+        <p class="text-primary">*{{bio_error}}</p>
     {% endif %}
     {{biography_form.bio_form}}
     <label for="{{biography_form.councilmatic_biography.id_for_label}}">Update {{biography_form.councilmatic_biography.label}}:</label>

--- a/lametro/templates/person/partials/person_headshot_form.html
+++ b/lametro/templates/person/partials/person_headshot_form.html
@@ -5,12 +5,11 @@
     {% csrf_token %}
 
     {% if headshot_error %}
-        <br>
-        <p style="color: #eb6864;">*{{headshot_error}}</p>
+        <p class="text-primary">*{{headshot_error}}</p>
     {% endif %}
     {{headshot_form.headshot_form}}
-    <label for="{{headshot_form.image.id_for_label}}">Update Headshot:</label>
-    <input type="file" name="headshot">
+    <label class="mb-2" for="{{headshot_form.image.id_for_label}}">Update Headshot:</label>
+    <input class="mb-2" type="file" name="headshot">
     <button class="btn btn-primary">Submit</button>
 
 </form>

--- a/lametro/templates/person/person.html
+++ b/lametro/templates/person/person.html
@@ -12,21 +12,19 @@
 
 {% block content %}
 
-    <div class="row-fluid">
-        <div class="col-sm-12">
-            <br/>
-            <h1>
-                <span>{{ person.name }}</span>
-                <br class="non-desktop-only"/>
-                <small>
-            {% if person.current_council_seat %}
-                {{ person.current_council_seat.role }}
-    	    {% else %}
-    	        Former {{ person.latest_council_membership.role }}
-    	    {% endif %}
-            <a href="rss/" title="RSS feed for Sponsored Board Actions by {{person.name}}"><i class="fa fa-rss-square" aria-hidden="true"></i></a>
-                </small>
-            </h1>
+    <div class="row">
+        <div class="col-12">
+            <h1 class="d-inline-block me-1">{{ person.name }}</h1>
+            <div class="d-inline-block">
+                <div class="text-secondary d-inline-block fw-normal h4">
+                    {% if person.current_council_seat %}
+                        {{ person.current_council_seat.role }}
+                    {% else %}
+                        Former {{ person.latest_council_membership.role }}
+                    {% endif %}
+                </div>
+                <a href="rss/" title="RSS feed for Sponsored Board Actions by {{person.name}}"><i class="fa fa-rss-square" aria-hidden="true"></i></a>
+            </div>
         </div>
     </div>
 
@@ -37,65 +35,52 @@
     {% if qualifying_post == 'Chief Executive Officer' %}
         {% include 'person/_person_ceo.html' %}
     {% else %}
-    <div class="row-fluid">
-        <div class="col-sm-4 non-mobile-only">
-            <img src='{{person.headshot_url}}' alt='{{person.name}}' title='{{person.name}}' class='img-responsive img-thumbnail img-padded' id="person-detail-headshot" />
-            <p class="small">
-                {% if qualifying_post %}
-                    <i class='fa fa-fw fa-briefcase'></i>
-                    {{ qualifying_post | appointment_label }}
-                {% endif %}
-            </p>
-            <p class="small"><a href="/about/#about-la-metro"><i class="fa fa-info-circle" aria-hidden="true"></i> More about Metro appointments</a> </p>
-
-            {% if user.is_authenticated %}
-            {% include './partials/person_headshot_form.html' %}
-            {% endif %}
-
-            <hr />
-
-            {% if map_geojson %}
-                <hr />
-                <h4>
-                    {% if person.current_district %}
-                        {{ person.current_district | format_district }} map
-                    {% endif %}
-                </h4>
-                <div id='map-detail'></div>
-            {% endif %}
-
-            {% if person.headshot_source %}
-                <p class='small'>
-                    <i class='fa fa-fw fa-camera'></i> Credit: {{person.headshot_source}}
-                </p>
-            {% endif %}
-
-        </div>
-
-        <div class="col-sm-4 mobile-only">
+    <div class="row">
+        <div class="col-md-4">
             <div class="row">
-                <div class="col-xs-4">
-                    <img src='{{person.headshot_url}}' alt='{{person.name}}' title='{{person.name}}' class='img-responsive img-thumbnail' />
+                <div class="col-sm-4 col-md-12">
+                    <img src='{{person.headshot_url}}' alt='{{person.name}}' title='{{person.name}}' class='img-responsive img-thumbnail img-padded' id="person-detail-headshot" />
                 </div>
-                <div class="col-xs-8">
-                    <p class="small">
-                        {% if qualifying_post %}
-                            <i class='fa fa-fw fa-briefcase'></i>
+
+                <div class="col-sm-6 col-md-12 mt-3 mt-md-0">
+                    {% if qualifying_post %}
+                        <p class="small mb-1">
+                            <i class='fa fa-fw fa-briefcase' aria-hidden="true"></i>
                             {{ qualifying_post | appointment_label }}
-                        {% endif %}
+                        </p>
+                    {% endif %}
+
+                    {% if person.headshot_source %}
+                        <p class='small'>
+                            <i class='fa fa-fw fa-camera' aria-hidden="true"></i>
+                            Credit: {{person.headshot_source}}
+                        </p>
+                    {% endif %}
+
+                    <p class="small">
+                        <a href="/about/#about-la-metro">
+                            <i class="fa fa-info-circle" aria-hidden="true"></i>
+                            More about Metro appointments
+                        </a>
                     </p>
 
-                    <p class="small"><a href="/about/#about-la-metro"><i class="fa fa-info-circle" aria-hidden="true"></i> More about Metro appointments</a> </p>
                     {% if user.is_authenticated %}
-                    {% include './partials/person_headshot_form.html' %}
+                        {% include './partials/person_headshot_form.html' %}
                     {% endif %}
                 </div>
             </div>
+            <hr aria-hidden="true">
 
-            <hr/>
+            {% if map_geojson %}
+                {% if person.current_district %}
+                    <h4>{{ person.current_district | format_district }} map</h4>
+                {% endif %}
+                <div id='map-detail'></div>
+            {% endif %}
+
         </div>
 
-        <div class='col-sm-8 no-pad-mobile'>
+        <div class="col-md-8 mt-3">
             {% if person.current_bio %}
                 <h3>
                     <i class="fa fa-user" aria-hidden="true"></i> About {{ person.name }}
@@ -103,46 +88,39 @@
                 <p class="bio">{{person.current_bio | safe}}</p>
             {% endif %}
 
-
             {% if user.is_authenticated %}
-            {% include './partials/person_bio_form.html' %}
+                {% include './partials/person_bio_form.html' %}
             {% endif %}
-            <br />
 
-            <ul class="nav nav-pills">
-                <li role="presentation" {% if request.GET.view == 'committees'  or request.GET.view == None %}class='active' {% endif %}>    <a href="/person/{{person.slug}}/?view=committees">
-                        <span class="small-pill">
-                            <i class='fa fa-fw fa-group'></i>
-                            Committees
-                        </span>
+            <ul class="nav nav-pills mb-4">
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link{% if request.GET.view == 'committees' or request.GET.view == None %} active{% endif %}" href="/person/{{person.slug}}/?view=committees">
+                        <i class="fa fa-fw fa-group" aria-hidden="true"></i>
+                        Committees
                     </a>
                 </li>
-                <li role="presentation" {% if request.GET.view == 'board-reports' %}class='active' {% endif %}>
-                    <a href="/person/{{person.slug}}/?view=board-reports">
-                        <span class="small-pill">
-                            <i class='fa fa-fw fa-files-o'></i>
-                            Board Reports
-                        </span>
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link{% if request.GET.view == 'board-reports' %} active{% endif %}" href="/person/{{person.slug}}/?view=board-reports">
+                        <i class="fa fa-fw fa-files-o" aria-hidden="true"></i>
+                        Board Reports
                     </a>
                 </li>
             </ul>
 
             {% if request.GET.view == 'committees' or request.GET.view == None %}
-
                 <h3>
-                    <i class='fa fa-fw fa-group'></i>
+                    <i class="fa fa-fw fa-group" aria-hidden="true"></i>
                     Committees
                 </h3>
-
-                <p>Committees to which {{person.name}} belongs</p><br />
+                <p class="mb-3">Committees to which {{person.name}} belongs</p>
 
                 <div class="table-responsive">
-                    <table class='table table-responsive'>
+                    <table class="table">
                         <thead>
                             <tr>
-                                <th>Member of</th>
-                                <th>Position</th>
-                                <th>Committee actions</th>
+                                <th scope="col">Member of</th>
+                                <th scope="col">Position</th>
+                                <th scope="col">Committee actions</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -160,23 +138,17 @@
                         </tbody>
                     </table>
                 </div>
-
             {% elif request.GET.view == 'board-reports' %}
                 <h3>
-                    <i class='fa fa-fw fa-files-o'></i>
+                    <i class="fa fa-fw fa-files-o" aria-hidden="true"></i>
                     Board Reports
                 </h3>
-
-                <p>Board reports acted upon most recently by committees to which {{person.name}} belongs</p><br />
+                <p class="mb-3">Board reports acted upon most recently by committees to which {{person.name}} belongs</p>
 
                 {% for legislation in sponsored_legislation %}
-
                     {% include "person/_legislation_item.html" %}
-
                 {% endfor %}
-
             {% endif %}
-
         </div>
     </div>
     {% endif %}


### PR DESCRIPTION
## Overview

This continues the template upgrade to bootstrap 5, this time for the person detail page.

Connects #969 

### Demo
<img width="1018" alt="image" src="https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/9847396c-1317-4155-9e17-701a3fef6fcc">

### Notes
On the live site, the map disappears on small screen sizes, which was either because it was overflowing the page or we didn't think it necessary to have on those sizes.

I have it showing up responsively on all sizes here, since I believe it could be useful to have that reminder of the person's jurisdiction regardless of screen size. If we think it's still too cluttered, lmk and I can remove it!

There was also some change in the presentation of the person's image at different screen sizes

## Testing Instructions

- Check some members' detail pages against their live versions on desktop and mobile window sizes
- Confirm that
  - they look presentable/similar to the original
  - the functionality across those two pages still works (maps, switching btwn related committees and board reports etc)
