### PR TITLE
Refactor event detail

### DIFF
--- a/lametro/templates/event/_agenda_pdf_form.html
+++ b/lametro/templates/event/_agenda_pdf_form.html
@@ -3,11 +3,11 @@
 
 <form role="form" method="POST" enctype="multipart/form-data">
     {% csrf_token %}
-    
+
     <!-- Upload a file and trigger the previewPDF function -->
     {{form.agenda}}
-    
-    <p class="hidden" id="pdf-form-message"><br>You submitted the below agenda. Does it look correct?</p>
+
+    <p class="hidden my-3" id="pdf-form-message">You submitted the below agenda. Does it look correct?</p>
     <iframe
         id="pdf-check-viewer-test"
         class="pdf-viewer hidden"
@@ -19,14 +19,10 @@
     </iframe>
 
     {% if form.agenda.errors %}
-        <br> 
-        <span class="error-block" style="color: #eb6864;">{{form.agenda.errors}}</span>
+        <span class="error-block text-primary d-block mt-3">{{form.agenda.errors}}</span>
     {% endif %}
 
     <button type="button" class="btn btn-default hidden" id="pdf-form-cancel"><i class="fa fa-times" aria-hidden="true"></i> No, that's not right</button>
     <button type="submit" class="btn btn-teal hidden" id="pdf-form-submit" name="{{name}}"><i class="fa fa-check" aria-hidden="true"></i> Looks good! Submit</button>
 
 </form>
-
-
-

--- a/lametro/templates/event/_agenda_url_form.html
+++ b/lametro/templates/event/_agenda_url_form.html
@@ -3,18 +3,15 @@
 
 <form role="form" method="POST" enctype="multipart/form-data">
     {% csrf_token %}
-    
+
     {{form.agenda}}
 
     {% if form.agenda.errors %}
-        <br> 
-        <span class="error-block" style="color: #eb6864;">{{form.agenda.errors}}</span>
+        <span class="error-block text-primary d-block mt-3">{{form.agenda.errors}}</span>
     {% endif %}
 
-    <br>
-
     <!-- Button trigger modal -->
-    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#{{name}}_modal">
+    <button type="button" class="btn btn-primary mt-3" data-bs-toggle="modal" data-bs-target="#{{name}}_modal">
       <i class="fa fa-arrow-right" aria-hidden="true"></i> Preview and Submit
     </button>
 
@@ -24,12 +21,13 @@
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title" id="agendaModalTitle">Agenda submission preview</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
               <p>You submitted the below agenda. Does it look correct?</p>
               <iframe
                   id="pdf-embed-agenda-check"
-                  class="pdf-viewer hidden-xs"
+                  class="pdf-viewer"
                   frameborder="0"
                   seamless="true"
                   width="100%"
@@ -39,7 +37,7 @@
           </div>
 
           <div class="modal-footer">
-            <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-times" aria-hidden="true"></i> No, that's not right</button>
+            <button type="button" class="btn btn-default" data-bs-dismiss="modal"><i class="fa fa-times" aria-hidden="true"></i> No, that's not right</button>
             <button type="submit" class="btn btn-teal" name="{{name}}"><i class="fa fa-check" aria-hidden="true"></i> Looks good! Submit</button>
           </div>
         </div>
@@ -47,7 +45,3 @@
     </div>
 
 </form>
-
-
-
-

--- a/lametro/templates/event/_event_header_live_public_comment.html
+++ b/lametro/templates/event/_event_header_live_public_comment.html
@@ -1,21 +1,23 @@
 <div class="row">
     {% if has_agenda and not event.has_passed %}
-    <div class="col-sm-7">
+    <div class="col-md-7">
     {% else %}
-    <div class="col-sm-12">
+    <div class="col-12">
     {% endif %}
 
         <p>{{event.description}}</p>
         <p class="small text-muted">
             {% if event.status == 'cancelled' %}
-                <strike>
-                <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}<br/>
-                <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}<br/>
-                </strike>
+                <del class="d-block">
+                    <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}
+                </del>
+                <del class="d-block">
+                    <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}
+                </del>
             {% else %}
-                <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}<br/>
-                <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}<br/>
-                <i class="fa fa-fw fa-map-marker"></i> {{event.location.name}}
+                <span class="d-block"><i class="fa fa-fw fa-calendar-o" aria-hidden="true"></i> {{event.start_time | date:"D n/d/Y"}}</span>
+                <span class="d-block"><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i> {{event.start_time | date:"g:i a"}}</span>
+                <span class="d-block"><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i> {{event.location.name}}</span>
             {% endif %}
         </p>
 
@@ -23,12 +25,13 @@
             {{ event.ecomment_message }}
             {% if event.is_ongoing %}
                 <p>
-                    <strong>You can submit your comments to the Metro Board of Directors during this meeting.</strong> Use the link below to comment on board reports on the agenda.
+                    <strong>You can submit your comments to the Metro Board of Directors during this meeting.</strong>
+                    Use the link below to comment on board reports on the agenda.
                 </p>
 
                 <p>
-                    <a class="btn btn-salmon" href="{{ event.ecomment_url }}" target="_blank">
-                        <i class='fa fa-fw fa-external-link'></i>
+                    <a class="btn btn-primary" href="{{ event.ecomment_url }}" target="_blank">
+                        <i class="fa fa-fw fa-external-link"></i>
                         Go to public comment
                     </a>
                 </p>
@@ -37,21 +40,21 @@
             {% endif %}
         {% endif %}
 
-        <p class="small">
-            {% if event.web_source.url %}
+        {% if event.web_source.url %}
+            <p class="small">
                 {% if not agenda_url and not uploaded_agenda_url and not uploaded_agenda_pdf %}
-                    Not seeing an agenda? Please use this link:<br>
+                    <span class="d-block">Not seeing an agenda? Please use this link:</span>
                 {% endif %}
-                <a href='{{event.web_source.url}}' title='View on the {{CITY_VOCAB.SOURCE}} website' target="_blank">
-                    <i class='fa fa-fw fa-external-link'></i>
+                <a href="{{event.web_source.url}}" title="View on the {{CITY_VOCAB.SOURCE}} website" target="_blank">
+                    <i class="fa fa-fw fa-external-link" aria-hidden="true"></i>
                     View on the {{CITY_VOCAB.SOURCE}} website
                 </a>
-            {% endif %}
-        </p>
+            </p>
+        {% endif %}
     </div>
 
     {% if has_agenda and not event.has_passed %}
-        <div class="col-sm-5">
+        <div class="col-md-5">
             <h4>Submit public comment remotely</h4>
 
             <p>
@@ -61,33 +64,31 @@
             <strong>By phone:</strong>
 
             {% if event.is_upcoming or event.is_ongoing %}
-
                 <p>You may join the public comment participation call 5 minutes prior to the start of the meeting.</p>
 
                 <p>
-                    <strong>Dial-in:</strong> 888-251-2949 or 215-861-0694<br/>
-                    <strong>English Access Code:</strong> 8231160#<br/>
-                    <strong>Spanish Access Code:</strong> 4544724#
+                    <span class="d-block"><strong>Dial-in:</strong> 888-251-2949 or 215-861-0694</span>
+                    <span class="d-block"><strong>English Access Code:</strong> 8231160#</span>
+                    <span class="d-block"><strong>Spanish Access Code:</strong> 4544724#</span>
                 </p>
 
                 <p>To give public comment on an item, enter #2 (pound two) when that item is taken up by the Board.</p>
 
-                <p>
-                    Need assistance with your audio? Please dial 888-796-6118.
-                </p>
+                <p>Need assistance with your audio? Please dial 888-796-6118.</p>
 
                 <p>
                     <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-                    <em>When you call in to comment, you will be able to hear the live stream of the meeting while you wait to comment. <strong>If you are also listening to the meeting on another device, please lower the volume on the second device to avoid feedback and ensure you can be heard clearly.</strong></em>
+                    <em>
+                        When you call in to comment, you will be able to hear the live stream of the meeting while you wait to comment.
+                        <strong>If you are also listening to the meeting on another device, please lower the volume on the second device to avoid feedback and ensure you can be heard clearly.</strong>
+                    </em>
                 </p>
-
-                <br />
 
                 {% if event.is_ongoing and USING_ECOMMENT %}
                     <p>
                         <strong>On the web:</strong>
                         <a href="{{ event.ecomment_url }}" target="_blank">
-                            <i class='fa fa-fw fa-external-link'></i>
+                            <i class="fa fa-fw fa-external-link" aria-hidden="true"></i>
                             Go to public comment
                         </a>
                     </p>
@@ -98,23 +99,31 @@
                 </p>
 
                 {% if USING_ECOMMENT %}
-                    <p>
-                        {{ event.UPCOMING_ECOMMENT_MESSAGE }}
-                    </p>
+                    <p>{{ event.UPCOMING_ECOMMENT_MESSAGE }}</p>
                 {% endif %}
 
-                <p>
-                    <strong>Before the meeting</strong><br />
+                <hr>
 
-                    <p>
-                        <strong>Via email:</strong> <a href="mailto:boardclerk@metro.net">boardclerk@metro.net</a><br />
-                        <strong>By postal mail:</strong> Office of Board Administration, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012
-                    </p>
+                <p>
+                    <strong class="d-block mb-2">Before the meeting</strong>
+
+                    <div>
+                        <strong>Via email:</strong>
+                        <a href="mailto:boardclerk@metro.net">boardclerk@metro.net</a>
+                    </div>
+
+                    <div>
+                        <strong>By postal mail: </strong>
+                        <address class="d-inline">Office of Board Administration, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012</address>
+                    </div>
                 </p>
 
                 <p>
                     <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-                    <em>Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail. <strong>Comments via mail must be received by 5pm on the day prior to the meeting.</strong></em>
+                    <em>
+                        Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail.
+                        <strong>Comments via mail must be received by 5pm on the day prior to the meeting.</strong>
+                    </em>
                 </p>
             {% endif %}
         </div>

--- a/lametro/templates/event/_event_header_no_live_public_comment.html
+++ b/lametro/templates/event/_event_header_no_live_public_comment.html
@@ -1,53 +1,64 @@
 <div class="row">
     {% if has_agenda and not event.has_passed %}
-    <div class="col-sm-7">
+    <div class="col-md-7">
     {% else %}
-    <div class="col-sm-12">
+    <div class="col-12">
     {% endif %}
 
         <p>{{event.description}}</p>
         <p class="small text-muted">
             {% if event.status == 'cancelled' %}
-                <strike>
-                <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}<br/>
-                <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}<br/>
-                </strike>
+                <del class="d-block">
+                    <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}
+                </del>
+                <del class="d-block">
+                    <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}
+                </del>
             {% else %}
-                <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}<br/>
-                <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}<br/>
-                <i class="fa fa-fw fa-map-marker"></i> {{event.location.name}}
+                <span class="d-block"><i class="fa fa-fw fa-calendar-o" aria-hidden="true"></i> {{event.start_time | date:"D n/d/Y"}}</span>
+                <span class="d-block"><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i> {{event.start_time | date:"g:i a"}}</span>
+                <span class="d-block"><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i> {{event.location.name}}</span>
             {% endif %}
         </p>
 
-        <p class="small">
-            {% if event.web_source.url %}
+
+        {% if event.web_source.url %}
+            <p class="small">
                 {% if not agenda_url and not uploaded_agenda_url and not uploaded_agenda_pdf %}
-                    Not seeing an agenda? Please use this link:<br>
+                    <span class="d-block">Not seeing an agenda? Please use this link:</span>
                 {% endif %}
-                <a href='{{event.web_source.url}}' title='View on the {{CITY_VOCAB.SOURCE}} website' target="_blank">
-                    <i class='fa fa-fw fa-external-link'></i>
+                <a href="{{event.web_source.url}}" title="View on the {{CITY_VOCAB.SOURCE}} website" target="_blank">
+                    <i class="fa fa-fw fa-external-link" aria-hidden="true"></i>
                     View on the {{CITY_VOCAB.SOURCE}} website
                 </a>
-            {% endif %}
-        </p>
+            </p>
+        {% endif %}
     </div>
 
     {% if has_agenda and not event.has_passed %}
-        <div class="col-sm-5">
+        <div class="col-md-5">
             <h4>Submit public comment remotely</h4>
 
             <p>
-                <strong>Before the meeting</strong><br />
+                <strong class="d-block mb-2">Before the meeting</strong>
 
-                <p>
-                    <strong>Via email:</strong> <a href="mailto:boardclerk@metro.net">boardclerk@metro.net</a><br />
-                    <strong>By postal mail:</strong> Office of Board Administration, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012
-                </p>
+                <div>
+                    <strong>Via email:</strong>
+                    <a href="mailto:boardclerk@metro.net">boardclerk@metro.net</a>
+                </div>
+
+                <div>
+                    <strong>By postal mail: </strong>
+                    <address class="d-inline">Office of Board Administration, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012</address>
+                </div>
             </p>
 
             <p>
                 <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-                <em>Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail. <strong>Comments via mail must be received by 5pm on the day prior to the meeting.</strong></em>
+                <em>
+                    Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail.
+                    <strong>Comments via mail must be received by 5pm on the day prior to the meeting.</strong>
+                </em>
             </p>
         </div>
     {% endif %}

--- a/lametro/templates/event/_related_bills.html
+++ b/lametro/templates/event/_related_bills.html
@@ -4,8 +4,8 @@
 <h4>Board Reports</h4>
 
 <p class="small text-muted">
-  Click "View" to go to the board report detail page.</br>
-  Click "Download" to download a copy of board report and its attachments.
+  <span class="d-block">Click "View" to go to the board report detail page.</span>
+  <span class="d-block">Click "Download" to download a copy of board report and its attachments.</span>
 </p>
 
 <div class="scrollable">
@@ -18,7 +18,11 @@
         <td>
           <a href='/board-report/{{ associated_bill.slug }}/' target="_blank">View</a>
         </td>
-        <td><a href={% if associated_bill.packet.is_ready %}"{{associated_bill.packet.url}}"{% else %}"{{associated_bill.board_report.url}}"{% endif %}>Download</a></td>
+        <td>
+          <a href={% if associated_bill.packet.is_ready %}"{{associated_bill.packet.url}}"{% else %}"{{associated_bill.board_report.url}}"{% endif %}>
+            Download
+          </a>
+        </td>
       </tr>
       {% endwith %}
   {% endfor %}

--- a/lametro/templates/event/event.html
+++ b/lametro/templates/event/event.html
@@ -6,193 +6,208 @@
 
 {% block content %}
 
-    <div class="row-fluid">
-        <div class="col-sm-12">
-            <br/>
-            <p>
-                <a href='/events/'>
-                    <i class="fa fa-angle-double-left" aria-hidden="true"></i>
-                    Back to {{ CITY_VOCAB.EVENTS }} &amp; Agendas
+    <div class="row">
+        <p>
+            <a href='/events/'>
+                <i class="fa fa-angle-double-left" aria-hidden="true"></i>
+                Back to {{ CITY_VOCAB.EVENTS }} &amp; Agendas
+            </a>
+        </p>
+
+        <!-- Header -->
+        <div class="col-12">
+        {% if event.status == 'cancelled' %}
+            <h1 class="d-inline-block"><del>{{event.name}}</del></h1>
+            <small class="label label-stale">Cancelled</small>
+        {% else %}
+            <h1>{{event.name}}</h1>
+        {% endif %}
+        </div>
+
+        {% if event.is_ongoing %}
+            <div class="col-7 col-sm-12">
+                <a class="btn btn-primary mb-2 mb-sm-0" href="{{ event.english_live_media_url }}"  target="_blank">
+                    <i class="fa fa-headphones" aria-hidden="true"></i>
+                    Watch in English
                 </a>
-            </p>
 
-            <!-- Header -->
-            <h1>
-                {% if event.status == 'cancelled' %}
-                    <strike>{{event.name}}</strike> <small><span class="label label-stale">Cancelled</span></small>
-                {% else %}
-                    {{event.name}}
-                {% endif %}
-
-                {% if event.is_ongoing %}
-                    <a class="btn btn-salmon" href="{{ event.english_live_media_url }}" target="_blank">
+                {% if event.bilingual %}
+                    <a class="btn btn-primary" href="{{ event.spanish_live_media_url }}" target="_blank">
                         <i class="fa fa-headphones" aria-hidden="true"></i>
-                        Watch in English
+                        Ver en Español
                     </a>
-
-                    {% if event.bilingual %}
-                        <a class="btn btn-salmon" href="{{ event.spanish_live_media_url }}" target="_blank">
-                            <i class="fa fa-headphones" aria-hidden="true"></i>
-                            Ver en Español
-                        </a>
-                    {% endif %}
-                {% else %}
-                    {% for media in event.media.all %}
-                        <a class="btn btn-salmon" href="{{ media.links.all.0.url }}" target="_blank"><i class= "fa fa-headphones" aria-hidden="true"></i> {% if media.note == 'Audio (SAP)' %}Ver en Español{% else %}Watch in English{% endif %}</a>
-                    {% endfor %}
                 {% endif %}
-                {% if user.is_authenticated %}
-                    {% if not event_ok %}
-                    <div class="well">
-                        <p>This event does not exist in Legistar. It may have been deleted from Legistar due to being a duplicate. To delete this event, click the button below.</p>
-                        <a href="{% url 'delete_event' event.slug %}" class='btn btn-teal'><i class="fa fa-times" aria-hidden="true"></i>Delete Event</a>
-                    </div>
-                    {% endif %}
-                {% endif %}
+            </div>
+        {% else %}
+            {% for media in event.media.all %}
+                <div>
+                    <a class="btn btn-primary" href="{{ media.links.all.0.url }}" target="_blank">
+                        <i class= "fa fa-headphones" aria-hidden="true"></i>
+                        {% if media.note == 'Audio (SAP)' %}Ver en Español{% else %}Watch in English{% endif %}
+                    </a>
+                </div>
+            {% endfor %}
+        {% endif %}
 
-            </h1>
-
-            {% if event.accepts_live_comment %}
-                {% include 'event/_event_header_live_public_comment.html' %}
-            {% else %}
-                {% include 'event/_event_header_no_live_public_comment.html' %}
+        {% if user.is_authenticated %}
+            {% if not event_ok %}
+            <div class="card-body">
+                <p class="card-text">This event does not exist in Legistar. It may have been deleted from Legistar due to being a duplicate. To delete this event, click the button below.</p>
+                <a href="{% url 'delete_event' event.slug %}" class='btn btn-teal'>
+                    <i class="fa fa-times" aria-hidden="true"></i>
+                    Delete Event
+                </a>
+            </div>
             {% endif %}
+        {% endif %}
 
-            <hr />
+        <!-- Details -->
+        {% if event.accepts_live_comment %}
+            {% include 'event/_event_header_live_public_comment.html' %}
+        {% else %}
+            {% include 'event/_event_header_no_live_public_comment.html' %}
+        {% endif %}
 
+        <hr>
+
+        <div class="col-12">
             <div class="row">
-                <div class="col-md-7">
+                <div class="col-lg-7">
                     {% if participants %}
                     <h4>Participants</h4>
                     <p>
                         {% for participant in participants %}
-                           <i class="fa fa-fw fa-users"></i> {{participant.link_html | safe}}<br />
+                        <span class="d-block"><i class="fa fa-fw fa-users" aria-hidden="true"></i> {{participant.link_html | safe}}</span>
                         {% endfor %}
                     </p>
                     {% endif %}
 
                     <!-- Check that the database has an agenda to display -->
-                    {% if has_agenda %}
+                    {% if has_agenda %} <!-- TODO: uncomment this, it's else, and it's endif when done -->
 
-                    <!-- An event can have both manually uploaded and auto-imported agendas, i.e., if a Metro Admin uploads an agenda and then import_data runs. Give the Admin an option to delete the manually uploaded agenda, but ONLY if an auto-imported agenda does not exist. -->
-                    {% if not agenda_url%}
-                        {% if user.is_authenticated %}
-                            <div class="well">
-                                <p>An admin submitted a URL to render this agenda. Not seeing what you expect? Delete this agenda, and afterwards, you can resubmit.</p>
-                                <a href="{% url 'delete_submission' event.slug %}" class='btn btn-teal'><i class="fa fa-times" aria-hidden="true"></i> Delete!</a>
+                        <!-- An event can have both manually uploaded and auto-imported agendas, i.e., if a Metro Admin uploads an agenda and then import_data runs. Give the Admin an option to delete the manually uploaded agenda, but ONLY if an auto-imported agenda does not exist. -->
+                        {% if not agenda_url and user.is_authenticated %}
+                            <div class="card-body mb-3">
+                                <p class="card-text">
+                                    An admin submitted a URL to render this agenda. Not seeing what you expect?
+                                    Delete this agenda, and afterwards, you can resubmit.
+                                </p>
+                                <a href="{% url 'delete_submission' event.slug %}" class="btn btn-teal">
+                                    <i class="fa fa-times" aria-hidden="true"></i> Delete!
+                                </a>
                             </div>
                         {% endif %}
-                    {% endif  %}
 
-                    <div class="row">
-                        <div class="col-xs-8">
-                            <h4>Agenda</h4>
-                            <p>
-                                <a id="pdf-download-link" target='_blank' href={% if agenda_url %}'{{agenda_url}}'{% elif uploaded_agenda_url %}'{{uploaded_agenda_url}}'{% elif uploaded_agenda_pdf %}'{% static uploaded_agenda_pdf %}'{% endif %}>
-                                    <i class="fa fa-file-text-o" aria-hidden="true"></i>
-                                    Download Agenda
-                                </a>
-                            </p>
-                            {% if event.packet.is_ready %}
-                            <p>
-                                <a href="{{event.packet.url}}"><i class="fa fa-files-o" aria-hidden="true"></i> Download Agenda and Attachments</a>
-                            </p>
-                            {% endif %}
+                        <div class="row">
+                            <div class="col-sm-8">
+                                <h4>Agenda</h4>
+                                <p class="mb-1">
+                                    <a id="pdf-download-link" target="_blank" href={% if agenda_url %} '{{agenda_url}}' {% elif uploaded_agenda_url %} '{{uploaded_agenda_url}}' {% elif uploaded_agenda_pdf %} '{% static uploaded_agenda_pdf %}' {% endif %}>
+                                        <i class="fa fa-file-text-o" aria-hidden="true"></i>
+                                        Download Agenda
+                                    </a>
+                                </p>
+                                {% if event.packet.is_ready %}
+                                    <p class="mb-1">
+                                        <a href="{{event.packet.url}}"><i class="fa fa-files-o" aria-hidden="true"></i>
+                                            Download Agenda and Attachments
+                                        </a>
+                                    </p>
+                                {% endif %}
+                            </div>
+                            <div class="col-sm-4">
+                                {% if event.start_time|compare_time %}
+                                        {% if minutes %}
+                                        <h4>Minutes</h4>
+                                        <p>
+                                            <a href="{{ minutes.links.get.url }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
+                                        </p>
+                                        {% elif 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
+                                        <h4>Minutes</h4>
+                                        <p>
+                                            <a href="http://boardarchives.metro.net/recaps/" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> View Recap</a>
+                                        </p>
+                                        {% endif %}
+                                {% endif %}
+                            </div>
                         </div>
-                        <div class="col-xs-4">
 
-                        {% if event.start_time|compare_time %}
-                            {% if minutes %}
-                            <h4>Minutes</h4>
-                            <p>
-                                <a href="{{ minutes.links.get.url }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
-                            </p>
-                            {% elif 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
-                            <h4>Minutes</h4>
-                            <p>
-                                <a href="http://boardarchives.metro.net/recaps/" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> View Recap</a>
-                                </br>
-                            </p>
-                            {% endif %}
-                        {% endif %}
-
-                        </div>
-                    </div>
-                    <p class="hidden-xs"><i>
-                      To use a link in the PDF below, hold the CTRL button on your keyboard when clicking the link.
-                    </i></p>
-                    <iframe
-                        id="pdf-embed-agenda"
-                        class="pdf-viewer hidden-xs"
-                        name="{{document_timestamp}}"
-                        frameborder="0"
-                        seamless="true"
-                        width="100%"
-                        height="600px"
-                        src={% if agenda_url %}"/pdfviewer/?{{agenda_url|full_text_doc_url}}"{% elif uploaded_agenda_url %}"/pdfviewer/?{{uploaded_agenda_url|full_text_doc_url}}"{% elif uploaded_agenda_pdf %}"{% static uploaded_agenda_pdf %}"{% endif %}>
-                    </iframe>
-
+                        <p class="d-none d-md-block">
+                            <em>To use a link in the PDF below, hold the CTRL button on your keyboard when clicking the link.</em>
+                        </p>
+                        <iframe
+                            id="pdf-embed-agenda"
+                            class="pdf-viewer d-none d-md-block"
+                            name="{{document_timestamp}}"
+                            frameborder="0"
+                            seamless="true"
+                            width="100%"
+                            height="600px"
+                            src={% if agenda_url %} "/pdfviewer/?{{agenda_url|full_text_doc_url}}" {% elif uploaded_agenda_url %} "/pdfviewer/?{{uploaded_agenda_url|full_text_doc_url}}" {% elif uploaded_agenda_pdf %} "{% static uploaded_agenda_pdf %}" {% endif %}>
+                        </iframe>
                     {% else %}
                         {% if user.is_authenticated %}
+                            <p>
+                                This event does not have an agenda. To add one, please provide a link to Legistar or directly upload a PDF.
+                                <span class="text-uppercase"><strong>Only upload a PDF during a Legistar outage!</strong></span>
+                            </p>
 
-                         <p>This event does not have an agenda. To add one, please provide a link to Legistar or directly upload a PDF. <span class="text-uppercase"><strong>Only upload a PDF during a Legistar outage!</strong></span></p>
-                         <br>
+                            <div class="accordion" id="accordionUpload" role="tablist" aria-multiselectable="true">
+                                <!-- URL Upload -->
+                                <div class="accordion-item">
+                                    <h4 class="accordion-header" id="headingOne" role="tab">
+                                        <button class="accordion-button {% if not url_form.errors %}collapsed{% endif %}" type="button" role="button" data-bs-toggle="collapse" data-bs-target="#collapseURL" aria-expanded="{% if url_form.errors %}true{%else%}false{% endif %}" aria-controls="collapseURL">
+                                            <i class="fa fa-link me-1" aria-hidden="true"></i>
+                                            Upload an Agenda URL
+                                        </button>
+                                    </h4>
+                                    <div id="collapseURL" class="accordion-collapse collapse {% if url_form.errors %}show{% endif %}" role="tabpanel" aria-labelledby="headingOne">
+                                        <div class="accordion-body">
+                                            <p>Find the corresponding agenda URL on Legistar, and paste it here.</p>
+                                            <!-- The variable "name" identifies the modal and form submit button -->
+                                            {% with form=url_form name='url_form' %}
+                                                {% include 'event/_agenda_url_form.html' %}
+                                            {% endwith %}
+                                        </div>
+                                    </div>
+                                </div>
 
-                        <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-                          <!-- URL Upload -->
-                          <div class="panel panel-default">
-                            <div class="panel-heading" role="tab" id="headingOne">
-                              <h4 class="panel-title">
-                                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseURL" aria-expanded="true" aria-controls="collapseURL">
-                                  <i class="fa fa-link" aria-hidden="true"></i> Upload an Agenda URL
-                                </a>
-                              </h4>
+                                <!-- PDF Upload -->
+                                <div class="accordion-item">
+                                    <h4 class="accordion-header" id="headingTwo" role="tab">
+                                        <button class="accordion-button {% if not pdf_form.errors %}collapsed{% endif %}" type="button" role="button" data-bs-toggle="collapse" data-bs-target="#collapsePDF" aria-expanded="{% if pdf_form.errors %}true{%else%}false{% endif %}" aria-controls="collapsePDF">
+                                            <i class="fa fa-file-text me-1" aria-hidden="true"></i>
+                                            Upload an Agenda PDF
+                                        </button>
+                                    </h4>
+                                    <div id="collapsePDF" class="accordion-collapse collapse {% if pdf_form.errors %}show{% endif %}" role="tabpanel" aria-labelledby="headingTwo">
+                                        <div class="accordion-body">
+                                            <div class="alert alert-info" role="alert">
+                                                <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+                                                {% if legistar_ok %}
+                                                    <strong>Caution!</strong> Our system does NOT detect a Legistar outage. Do not use this option.
+                                                {% else %}
+                                                    Our system detects a Legistar outage. Proceed with this option but exercise caution.
+                                                {% endif %}
+                                            </div>
+
+                                            <!-- The variable "name" identifies the modal and form submit button -->
+                                            {% with form=pdf_form name='pdf_form' %}
+                                                {% include 'event/_agenda_pdf_form.html' %}
+                                            {% endwith %}
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
-                            <div id="collapseURL" class="panel-collapse collapse {% if url_form.errors %}in{% endif %}" role="tabpanel" aria-labelledby="headingOne">
-                              <div class="panel-body">
-
-                                <p>Find the corresponding agenda URL on Legistar, and paste it here.</p>
-                                <!-- The variable "name" identifies the modal and form submit button -->
-                                {% with form=url_form name='url_form' %}
-                                    {% include 'event/_agenda_url_form.html' %}
-                                {% endwith %}
-
-                              </div>
-                            </div>
-                          </div>
-                          <!-- PDF Upload -->
-                          <div class="panel panel-default">
-                            <div class="panel-heading" role="tab" id="headingTwo">
-                              <h4 class="panel-title">
-                                <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapsePDF" aria-expanded="false" aria-controls="collapsePDF">
-                                  <i class="fa fa-file-text" aria-hidden="true"></i> Upload an Agenda PDF
-                                </a>
-                              </h4>
-                            </div>
-                            <div id="collapsePDF" class="panel-collapse collapse {% if pdf_form.errors %}in{% endif %}" role="tabpanel" aria-labelledby="headingTwo">
-                              <div class="panel-body">
-                                {% if legistar_ok %}
-                                    <div class="alert alert-info" role="alert"><i class="fa fa-exclamation-circle" aria-hidden="true"></i> <strong>Caution!</strong> Our system does NOT detect a Legistar outage. Do not use this option.</div>
-                                {% else %}
-                                    <div class="alert alert-info" role="alert"><i class="fa fa-exclamation-circle" aria-hidden="true"></i> Our system detects a Legistar outage. Proceed with this option but exercise caution.</div>
-                                {% endif %}
-
-                                <!-- The variable "name" identifies the modal and form submit button -->
-                                {% with form=pdf_form name='pdf_form' %}
-                                    {% include 'event/_agenda_pdf_form.html' %}
-                                {% endwith %}
-
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-
                         {% else %}
-                        <p>Agenda will be posted no later than 72 hours prior to the start of the meeting, or 24 hours for Special Board meetings. If you are unable to access an Agenda within either of these time frames, please visit: <a href="http://metro.legistar.com/calendar.aspx" target="_blank">http://metro.legistar.com/calendar.aspx</a>.</p>
+                            <p>
+                                Agenda will be posted no later than 72 hours prior to the start of the meeting, or 24 hours for Special Board meetings.
+                                If you are unable to access an Agenda within either of these time frames, please visit: <a href="http://metro.legistar.com/calendar.aspx" target="_blank">http://metro.legistar.com/calendar.aspx</a>.
+                            </p>
                         {% endif %}
                     {% endif %}
                 </div>
-                <div class="col-md-5">
+                <div class="col-lg-5">
                     {% if event.documents.all %}
                         {% include 'event/_related_bills.html' %}
                     {% endif %}
@@ -200,6 +215,7 @@
             </div>
         </div>
     </div>
+
 
     <script type="application/ld+json">
     {


### PR DESCRIPTION
## Overview

This continues the template upgrade to bootstrap 5, this time for the event detail page.

Connects #969 and #996

### Demo

![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/ef5594e5-d488-4f17-837a-4b212eec5c38)

---

![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/4f7330b2-5dcd-4cee-8925-e6fa2e6b9afa)

## Testing Instructions

- Check some events' detail pages against their live versions on desktop and mobile window sizes
- Confirm that
  - they look presentable/similar to the original
  - the functionality still works (accordions interact-able when logged in, pdf displaying properly, etc)
