### PR TITLE
Refactor events listing

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -270,9 +270,6 @@ div#toggleControls { margin-bottom: 1em; }
     border-top-left-radius: 6px;
 }
 
-/* Styles for calendar pop-up. */
-#date-search .form-control { width: 50%; }
-
 .form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control {
     background-color: #fff;
 }
@@ -282,7 +279,7 @@ div#toggleControls { margin-bottom: 1em; }
 
 .btn-teal {
     background-color: #49A6AB;
-    border: #49A6AB;
+    border: 1px solid #49A6AB;
     color: #fff;
 }
 

--- a/lametro/templates/event/event.html
+++ b/lametro/templates/event/event.html
@@ -207,7 +207,7 @@
                         {% endif %}
                     {% endif %}
                 </div>
-                <div class="col-lg-5">
+                <div class="col-lg-5 mt-4 mt-lg-0">
                     {% if event.documents.all %}
                         {% include 'event/_related_bills.html' %}
                     {% endif %}

--- a/lametro/templates/events/_event_day.html
+++ b/lametro/templates/events/_event_day.html
@@ -1,7 +1,7 @@
-<h5 class="text-default">
-  <i class="fa fa-fw fa-calendar-o"></i> {{date | date:"D m/d/Y"}}
-  <div class="divider"></div>
+<h5 class="text-default m-0">
+  <i class="fa fa-fw fa-calendar-o" aria-hidden="true"></i> {{date | date:"D m/d/Y"}}
 </h5>
+<div class="divider" aria-hidden="true"></div>
 
 {% for event in event_list %}
   {% include "events/_event_time_item.html" %}

--- a/lametro/templates/events/_event_time_item.html
+++ b/lametro/templates/events/_event_time_item.html
@@ -1,43 +1,33 @@
 {% load lametro_extras %}
 
+{% if not forloop.first %}
+    <hr class="events-line mt-0" aria-hidden="true"/>
+{% endif %}
+
 <a href="{{event.event_page_url}}">
-  {% if forloop.last %}
-  <div class="row" style="margin-bottom: 30px;">
-  {% else %}
   <div class="row">
-  {% endif %}
+        <div class="col-3 pe-0">
 
-  {% if not forloop.first %}
-    <hr class="events-line"/>
-  {% endif %}
-        <div class="col-xs-3 no-pad-right">
-
-            {% if event.status == 'cancelled' %}<strike>{% endif %}
+            {% if event.status == 'cancelled' %}<del>{% endif %}
 
             <p class="small">
-                <span class="non-mobile-only">
-                    <i class="fa fa-fw fa-clock-o"></i> {{event.start_time| date:"g:i a"}}<br/>
-                </span>
-                <span class="mobile-only">
-                    {{event.start_time| date:"g:i a"}}<br/>
-                </span>
+                <i class="fa fa-fw fa-clock-o d-none d-sm-inline" aria-hidden="true"></i>
+                {{event.start_time| date:"g:i a"}}
             </p>
 
-            {% if event.status == 'cancelled' %}</strike>{% endif %}
+            {% if event.status == 'cancelled' %}</del>{% endif %}
 
         </div>
-        <div class="col-xs-9">
+        <div class="col-9">
             <p>
                 {% if event.status == 'cancelled' %}
-                    <strike>{{event.name}}</strike>
+                    <del>{{event.name}}</del>
                     <span class="label label-stale">Cancelled</span>
-                    <br/>
                 {% else %}
                     {{event.name}}
                     {% if event|updates_made %}
                         <span class='label label-info label-teal'>Updated</span>
                     {% endif %}
-                    <br/>
                 {% endif %}
             </p>
         </div>

--- a/lametro/templates/events/_events_info_blurb.html
+++ b/lametro/templates/events/_events_info_blurb.html
@@ -1,5 +1,8 @@
-<div class='well info-blurb'>
-    <h4><i class='fa fa-fw fa-info-circle'></i> What are these {{ CITY_VOCAB.EVENTS | lower}}?</h4>
+<div class='card-body mb-3'>
+    <div class="my-2">
+        <span class="h5"><i class='fa fa-fw fa-info-circle text-dark' aria-hidden="true"></i></span>
+        <h5 class="d-inline"> What are these {{ CITY_VOCAB.EVENTS | lower}}?</h5>
+    </div>
 
     {{ ABOUT_BLURBS.EVENTS | safe }}
 

--- a/lametro/templates/events/_past_event_day.html
+++ b/lametro/templates/events/_past_event_day.html
@@ -1,60 +1,51 @@
 {% load lametro_extras %}
 
-<h5 class="text-default">
-    <i class="fa fa-fw fa-calendar-o"></i> {{date | date:"D m/d/Y"}}
-    <div class="divider"></div>
+<h5 class="text-default m-0">
+    <i class="fa fa-fw fa-calendar-o" aria-hidden="true"></i> {{date | date:"D m/d/Y"}}
 </h5>
+<div class="divider" aria-hidden="true"></div>
+
 {% for event in event_list %}
 
-  {% if forloop.last %}
-  <div class="row" style="margin-bottom: 30px;">
-  {% else %}
-  <div class="row">
-  {% endif %}
-
   {% if not forloop.first %}
-    <hr class="events-line" />
+    <hr class="events-line mt-0" aria-hidden="true"/>
   {% endif %}
 
-    <div class="col-xs-3 no-pad-right">
+  <div class="row">
+    <div class="col-3 pe-0">
 
-        {% if event.status == 'cancelled' %}<strike>{% endif %}
+        {% if event.status == 'cancelled' %}<del>{% endif %}
 
         <p class="small">
-            <span class="non-mobile-only">
-                <i class="fa fa-fw fa-clock-o"></i> {{event.start_time| date:"g:i a"}}<br/>
-            </span>
-            <span class="mobile-only">
-                {{event.start_time| date:"g:i a"}}<br/>
-            </span>
+            <i class="fa fa-fw fa-clock-o d-none d-sm-inline" aria-hidden="true"></i>
+            {{event.start_time| date:"g:i a"}}
         </p>
 
-        {% if event.status == 'cancelled' %}</strike>{% endif %}
+        {% if event.status == 'cancelled' %}</del>{% endif %}
 
     </div>
-    <div class="col-xs-4">
+
+    <div class="col-4">
         <p>
             {% if event.status == 'cancelled' %}
-                <strike><a href="{{event.event_page_url}}">{{event.name}}</a></strike>
+                <del><a href="{{event.event_page_url}}">{{event.name}}</a></del>
                 <span class="label label-stale">Cancelled</span>
             {% else %}
                 <a href="{{event.event_page_url}}">{{event.name}}</a>
             {% endif %}
-            <br/>
         </p>
     </div>
 
-    <div class="col-xs-3">
+    <div class="col-3">
         {% for media in event.media.all %}
           <p>
             <a href="{{ media.links.all.0.url }}" target="_blank">{% if media.note == 'Audio (SAP)' %}Ver en Español{% else %}Watch in English{% endif %}</a>
-            </br>
           </p>
         {% endfor %}
     </div>
 
     {% if event.start_time|compare_time %}
-    <div class="col-xs-1">
+    <div class="col-2 p-0">
         {% with minutes=event.minutes.0.links.all.0.url %}
             {% if minutes %}
             <p>
@@ -63,7 +54,6 @@
             {% elif 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
             <p>
                 <a href="http://boardarchives.metro.net/recaps/" target="_blank">Recap</a>
-                </br>
             </p>
             {% endif %}
         {% endwith %}

--- a/lametro/templates/events/events.html
+++ b/lametro/templates/events/events.html
@@ -11,38 +11,41 @@
 {% endblock %}
 
 {% block content %}
-    <div class="row-fluid">
-        <div class="col-sm-9 no-pad-mobile">
-            <br/><br class="non-mobile-only"/>
-            <div id="events-form" class="row">
-                <div class="col-xs-8">
+    <div class="row">
+        <div class="col-md-9 px-0 px-md-3">
+
+            <div class="row" id="events-form">
+                <h2>Select a date range</h2>
+                <div class="col-lg-8">
                     <form action='/events' method='GET'>
-
-                      <div class="input-group" id='date-search'>
-                            <span class="input-group-addon" id="sizing-addon3"><i class="fa fa-calendar" aria-hidden="true"></i></span>
-                            <input type="text" id="from" name="from" class="form-control date-filter" placeholder="Select start date..." value='{{ start_date }}'>
-                            <input type="text" id="to" name="to" class="form-control date-filter" placeholder="Select end date..." value='{{ end_date }}'>
-                            <span class="input-group-btn">
-                              <button class="btn btn-default btn-date" id="btn-search" type="submit"><i class="fa fa-search" aria-hidden="true"></i> <span class='hidden-sm hidden-xs'>Search</span></button>
-                            </span>
-                      </div>
-
+                        <div class="input-group" id='date-search'>
+                            <span class="input-group-text" id="basic-addon1"><i class="fa fa-calendar" aria-hidden="true"></i></span>
+                            <input type="text" id="from" name="from" class="form-control date-filter" placeholder="From..." value='{{ start_date }}' autocomplete="off">
+                            <input type="text" id="to" name="to" class="form-control date-filter" placeholder="To..." value='{{ end_date }}' autocomplete="off">
+                            <button class="btn btn-secondary btn-date" id="btn-search" type="submit"><i class="fa fa-search" aria-hidden="true"></i> <span class='d-none d-sm-inline'>Search</span></button>
+                        </div>
                     </form>
                 </div>
-                <div class="col-xs-2">
-                    <a href="{% url 'events' %}?show=all" class="btn btn-salmon d-inline-block"><i class="fa fa-list" aria-hidden="true"></i><span class="hidden-xs"> All meetings</span></a>
+                <div class="col-lg-4 my-2 my-lg-0">
+                    <a href="{% url 'events' %}?show=all" class="btn btn-primary d-inline-block px-lg-2">
+                        <i class="fa fa-list" aria-hidden="true"></i>
+                        All meetings
+                    </a>
+                    <a href="{% url 'events' %}" class="btn btn-teal d-inline-block px-lg-2">
+                        <i class="fa fa-repeat" aria-hidden="true"></i>
+                        Reset
+                    </a>
                 </div>
-                <div class="col-xs-2">
-                    <a href="{% url 'events' %}" class="btn btn-teal d-inline-block"><i class="fa fa-repeat" aria-hidden="true"></i><span class="hidden-xs"> Reset</span></a>
-                </div>
-            </div><br class="non-mobile-only"/>
+            </div>
 
             {% if request.user.is_authenticated %}
             <div class="row">
-                <div class="col-md-10">
-                    <div class="well login">
+                <div class="col-lg-10">
+                    <div class="card-body login">
                         <h4>Hello, {{ user.username }}!</h4>
-                        <p>You have the authority to add agenda links to relevant events. Please click on an event that needs an agenda, and look for the URL input box.</p>
+                        <p>You have the authority to add agenda links to relevant events.
+                            Please click on an event that needs an agenda, and look for the URL input box.
+                        </p>
                         <p><em>You only have this option for events without agendas.</em></p>
                     </div>
                 </div>
@@ -50,122 +53,163 @@
             {% endif %}
 
             {% if future_events %}
-                <h2><span>Upcoming {{ CITY_VOCAB.EVENTS }}</span>
-                <br class="non-desktop-only"/>
-                <small>
-                    <a href="rss/" title="RSS feed for Upcoming and Recent Events">
-                        <i class="fa fa-rss-square" aria-hidden="true"></i>
-                    </a>
-                    <p>
-                        Download event calendar:
-                        <a href="{% static 'pdf/fy23-committee-board-calendar.pdf' %}" target="_blank" class="btn btn-link">
-                            <i class="fa fa-fw fa-download" aria-hidden="true"></i>
-                            Fiscal Year 2023 (PDF)
-                        </a>
-                        <a href="{% static 'pdf/fy24-committee-board-calendar.pdf' %}" target="_blank" class="btn btn-link">
+                <div class="row mt-4">
+                    <div>
+                        <h2 class="d-inline">Upcoming {{ CITY_VOCAB.EVENTS }}</h2>
+                        <small class="rss">
+                            <a href="rss/" title="RSS feed for Upcoming and Recent Events">
+                                <i class="fa fa-rss-square" aria-hidden="true"></i>
+                            </a>
+                        </small>
+                    </div>
+                    <p class="mt-3 mt-sm-0">
+                        <span>Download event calendar:</span>
+                        <a href="{% static 'pdf/fy24-committee-board-calendar.pdf' %}" target="_blank" class="btn btn-link pt-0 d-block d-sm-inline text-start">
                             <i class="fa fa-fw fa-download" aria-hidden="true"></i>
                             Fiscal Year 2024 (PDF)
                         </a>
                     </p>
-                </small>
-                </h2><br class="non-mobile-only"/>
-
-                <div class='row'>
-                    <div class='col-sm-8' id='events_message'></div>
                 </div>
 
+                <div class='row'>
+                    <div class='col-md-8' id='events_message'></div>
+                </div>
+
+                <div class="row mt-4">
                 {% for date, event_list in future_events %}
-                    <div class="event-upcoming-listing">
+                    <div class="event-upcoming-listing mb-4">
                         {% include "events/_event_day.html" %}
                     </div>
                 {% endfor %}
-
-                <a href="" class="btn btn-salmon" id="more-upcoming-events"><i class="fa fa-fw fa-chevron-down"></i>Show all upcoming meetings</a>
-                <a href="" class="btn btn-salmon" id="fewer-upcoming-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer upcoming meetings</a>
-
-                <h2 style="margin-top: 40px;"><span>Past {{ CITY_VOCAB.EVENTS }}</span>
-                <br class="non-desktop-only"/>
-                <small><a href="rss/" title="RSS feed for Upcoming and Recent Events"><i class="fa fa-rss-square" aria-hidden="true"></i></a></small>
-                </h2><br class="non-mobile-only"/>
-
-                <div class='row'>
-                    <div class='col-sm-8' id='events_message'></div>
                 </div>
 
+                <a href="" class="btn btn-primary" id="more-upcoming-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all upcoming meetings</a>
+                <a href="" class="btn btn-primary" id="fewer-upcoming-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer upcoming meetings</a>
+
+                <div class="row mt-5">
+                    <div>
+                        <h2 class="d-inline">Past {{ CITY_VOCAB.EVENTS }}</h2>
+                        <small class="rss">
+                            <a href="rss/" title="RSS feed for Upcoming and Recent Events">
+                                <i class="fa fa-rss-square" aria-hidden="true"></i>
+                            </a>
+                        </small>
+                    </div>
+                </div>
+
+                <div class='row'>
+                    <div class='col-md-8' id='events_message'></div>
+                </div>
+
+                <div class="row mt-4">
                 {% for date, event_list in past_events %}
-                    <div class='event-listing'>
-                    {% include "events/_past_event_day.html" %}
+                    <div class='event-listing mb-4'>
+                        {% include "events/_past_event_day.html" %}
                     </div>
                 {% endfor %}
+                </div>
 
-                <a href="" class="btn btn-salmon" id="more-events"><i class="fa fa-fw fa-chevron-down"></i>Show all past meetings</a>
-                <a href="" class="btn btn-salmon" id="fewer-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer past meetings</a>
+                <a href="" class="btn btn-primary mb-5" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all past meetings</a>
+                <a href="" class="btn btn-primary mb-5" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer past meetings</a>
 
             {% elif past_events %}
-                <h2 style="margin-top: 40px;"><span>Past {{ CITY_VOCAB.EVENTS }}</span>
-                <br class="non-desktop-only"/>
-                <small><a href="rss/" title="RSS feed for Upcoming and Recent Events"><i class="fa fa-rss-square" aria-hidden="true"></i></a></small>
-                </h2><br class="non-mobile-only"/>
-
-                <div class='row'>
-                    <div class='col-sm-8' id='events_message'></div>
+                <div class="row mt-4">
+                    <div>
+                        <h2 class="d-inline">Past {{ CITY_VOCAB.EVENTS }}</h2>
+                        <small class="rss">
+                            <a href="rss/" title="RSS feed for Upcoming and Recent Events">
+                                <i class="fa fa-rss-square" aria-hidden="true"></i>
+                            </a>
+                        </small>
+                    </div>
                 </div>
 
+                <div class='row'>
+                    <div class='col-md-8' id='events_message'></div>
+                </div>
+
+                <div class="row mt-4">
                 {% for date, event_list in past_events %}
-                    <div class='event-listing'>
-                    {% include "events/_past_event_day.html" %}
+                    <div class='event-listing mb-4'>
+                        {% include "events/_past_event_day.html" %}
                     </div>
                 {% endfor %}
-
-                <a href="" class="btn btn-salmon" id="more-events"><i class="fa fa-fw fa-chevron-down"></i>Show all past meetings</a>
-                <a href="" class="btn btn-salmon" id="fewer-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer past meetings</a>
-            {% elif select_events %}
-                <h2><span>{{ CITY_VOCAB.EVENTS }} from {{ start_date }} to {{ end_date }}</span>
-                <br class="non-desktop-only"/>
-                <small><a href="rss/" title="RSS feed for Upcoming and Recent Events"><i class="fa fa-rss-square" aria-hidden="true"></i></a></small>
-                </h2>
-
-                <div class='row'>
-                    <div class='col-sm-8' id='events_message'></div>
                 </div>
 
+                <a href="" class="btn btn-primary mb-5" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all past meetings</a>
+                <a href="" class="btn btn-primary mb-5" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer past meetings</a>
+
+            {% elif select_events %}
+                <div class="row mt-4">
+                    <div>
+                        <h2 class="d-inline">{{ CITY_VOCAB.EVENTS }} from {{ start_date }} to {{ end_date }}</h2>
+                        <small class="rss">
+                            <a href="rss/" title="RSS feed for Upcoming and Recent Events">
+                                <i class="fa fa-rss-square" aria-hidden="true"></i>
+                            </a>
+                        </small>
+                    </div>
+                </div>
+
+                <div class='row'>
+                    <div class='col-md-8' id='events_message'></div>
+                </div>
+
+                <div class="row mt-4">
                 {% for date, event_list in select_events %}
-                    {% include "events/_past_event_day.html" %}
+                    <div class='mb-4'>
+                        {% include "events/_past_event_day.html" %}
+                    </div>
                 {% endfor %}
+                </div>
 
             {% elif all_events %}
-                <h2><span>All {{ CITY_VOCAB.EVENTS }}</span>
-                <br class="non-desktop-only"/>
-                <small><a href="rss/" title="RSS feed for Upcoming and Recent Events"><i class="fa fa-rss-square" aria-hidden="true"></i></a></small>
-                </h2>
-
-                <div class='row'>
-                    <div class='col-sm-8' id='events_message'></div>
-                </div>
-
-                {% for date, event_list in all_events %}
-                    {% include "events/_past_event_day.html" %}
-                {% endfor %}
-            {% else %}
-                <div class='row'>
-                    <div class="col-sm-12">
-                        <br>
-                        <p>Your search did not return any results.</p>
+                <div class="row mt-4">
+                    <div>
+                        <h2 class="d-inline">All {{ CITY_VOCAB.EVENTS }}</h2>
+                        <small class="rss">
+                            <a href="rss/" title="RSS feed for Upcoming and Recent Events">
+                                <i class="fa fa-rss-square" aria-hidden="true"></i>
+                            </a>
+                        </small>
                     </div>
                 </div>
-            {% endif %}
 
+                <div class='row'>
+                    <div class='col-md-8' id='events_message'></div>
+                </div>
+
+                <div class="row mt-4">
+                {% for date, event_list in all_events %}
+                    <div class='mb-4'>
+                        {% include "events/_past_event_day.html" %}
+                    </div>
+                {% endfor %}
+                </div>
+
+            {% else %}
+                <div class='row my-4'>
+                    <h5>Your search did not return any results.</h5>
+                </div>
+            {% endif %}
         </div>
-        <div class="col-sm-3 no-pad-mobile">
-            <br/><br class="non-mobile-only"/>
+
+        <div class="col-md-3 px-0 px-md-2">
             {% include 'events/_events_info_blurb.html' %}
 
             <div>
-                <p><a href="{% url 'about' %}#rules"><i class="fa fa-gavel" aria-hidden="true"></i> Board Room Rules</a></p>
-                <p><a href="{% url 'about' %}#procedures"><i class="fa fa-book" aria-hidden="true"></i> Rules &amp; Procedures</a></p>
-                <p><a href="{% url 'about' %}#visit"><i class="fa fa-map-marker" aria-hidden="true"></i> Visit Metro Headquarters Building</a></p>
+                <p class="my-2">
+                    <a href="{% url 'about' %}#rules"><i class="fa fa-gavel" aria-hidden="true"></i> Board Room Rules</a>
+                </p>
+                <p class="my-2">
+                    <a href="{% url 'about' %}#procedures"><i class="fa fa-book" aria-hidden="true"></i> Rules &amp; Procedures</a>
+                </p>
+                <p class="my-2">
+                    <a href="{% url 'about' %}#visit"><i class="fa fa-map-marker" aria-hidden="true"></i> Visit Metro Headquarters Building</a>
+                </p>
             </div>
         </div>
+
     </div>
 
 {% endblock %}


### PR DESCRIPTION
## Overview

This continues the template upgrade to bootstrap 5, this time for the events listing page. Notable changes are:

 - The display of the two top buttons (All Meetings and Reset) have been changed for clarity. They will now adjust responsively in order to always display their text, resolving the lack of clarity on mobile sizes described in #996.
 - Previously the informative placeholder text in the date pickers cut off substantially at small mobile sizes. This text has been changed and a new heading above the date pickers has been added in order to also address clarity.
 - Autocomplete has been turned off for the date picker inputs because it was blocking the picker popup.
 - The "Minutes" and "Recap" links that occasionally appear next to search results was getting right up on the edge of the screen for small screen sizes. Removing their padding helps to back them up a bit.

Connects #969 
Closes #996

### Demo

![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/56a53bb9-d339-45a4-9236-9095bc8191a1)

---

![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/ab50d886-3d15-428b-9888-cdb019e32bf5)

## Testing Instructions

 - Check different kinds of results in the events listing page against their live versions on desktop and mobile window sizes
   - "Different kinds" includes the default results (upcoming/past meetings), all meetings, and date range meetings.
 - Confirm that
   - the different kinds of results look presentable/similar to the original
   - the functionality still works (selecting dates, showing more meetings, etc)
