### PR TITLE
Refactor committee listing and details

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -635,3 +635,11 @@ small.rss {
 input[name="headshot"] {
     width: 100%;
 }
+
+#committees tbody > tr:last-child > td {
+    border-bottom: 0;
+}
+
+#committees thead th {
+    border-bottom-width: 2px;
+}

--- a/lametro/templates/committee.html
+++ b/lametro/templates/committee.html
@@ -5,114 +5,117 @@
 {% block title %}{{committee.name}}{% endblock %}
 
 {% block content %}
-
-    <div class="row-fluid">
-        <div class="col-sm-8">
-            <br/>
-            <h1>{{committee.name }}</h1>
-            {% if committee_description %}
-                <p>{{committee_description}}</p>
-            {% endif %}
-
-        </div>
+<div class="row">
+    <div class="col-md-8">
+        <h1>{{committee.name}}</h1>
+        {% if committee_description %}
+            <p>{{committee_description}}</p>
+        {% endif %}
     </div>
+</div>
 
-    <div class="row-fluid">
-        <div class="col-sm-12">
-        <hr />
-        </div>
+<div class="row my-3" aria-hidden="true">
+    <div>
+        <hr>
     </div>
+</div>
 
-    <div class="row-fluid">
-        <div class="col-sm-12">
-            {% if committee.recent_events %}
-                <h4>
-                    <i class='fa fa-fw fa-calendar-o'></i> Committee {{ CITY_VOCAB.EVENTS }}
-                    <a href="events/rss/" title="RSS feed for Committe Events by {{committee.name}}"><i class="fa fa-rss-square" aria-hidden="true"></i></a>
+<div class="row">
+    <div class="col-12">
+        {% if committee.recent_events %}
+            <div class="mb-4">
+                <h4 class="d-inline">
+                    <i class='fa fa-fw fa-calendar-o' aria-hidden="true"></i>
+                    Committee {{ CITY_VOCAB.EVENTS }}
                 </h4>
-                <br>
-                {% for event in committee.recent_events %}
-                    <p class="event-listing">
+                <small class="rss">
+                    <a href="events/rss/" title="RSS feed for Committe Events by {{committee.name}}">
+                        <i class="fa fa-rss-square" aria-hidden="true"></i>
+                    </a>
+                </small>
+            </div>
+
+            {% for event in committee.recent_events %}
+                <p class="event-listing my-2">
                     {% if event.status == 'cancelled' %}
-                        <strike>
-                            {{ event.start_time | date:'n/d/Y' }} - {{ event.link_html | safe }}
-                        </strike>
+                        <del>{{ event.start_time | date:'n/d/Y' }} - {{ event.link_html | safe }}</del>
                         <span class="label label-stale">Cancelled</span>
                     {% else %}
                         {{ event.start_time | date:'n/d/Y' }} - {{ event.link_html | safe}}
                     {% endif %}
-                    </p>
+                </p>
+            {% endfor %}
+            <a href="" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show more</a>
+            <a href="" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer</a>
+        {% endif %}
+    </div>
+</div>
+
+<div class="row my-3" aria-hidden="true">
+    <div>
+        <hr>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-8">
+        <h4><i class='fa fa-fw fa-group' aria-hidden="true"></i> Committee Members</h4>
+
+        <table class="table" id="council-members">
+            <thead>
+                <tr>
+                    <th scope="col"></th>
+                    <th scope="col">Member</th>
+                    <th scope="col">Title</th>
+                    <th class="no-wrap" scope="col">
+                        <span class="d-none d-sm-inline">Committee </span>Role
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for membership in non_ceos %}
+                <tr>
+                    <td data-order="{{ membership.index }}">
+                        <div class="thumbnail-square">
+                            <img src="{{ membership.person.headshot_url }}" alt="{{membership.person.name}}" title="{{membership.person.name}}" class="img-responsive img-thumbnail">
+                        </div>
+                    </td>
+                    <td>
+                        {% if membership.person.latest_council_membership %}
+                            <a href="{% url 'lametro:person' membership.person.slug %}">{{ membership.person.name }}</a>
+                        {% else %}
+                            {{ membership.person.name }}
+                        {% endif %}
+                    </td>
+                    <td>
+                        {{ membership.extras | clean_membership_extras }} {{ membership.person.latest_council_membership.post.label | format_label }}
+                    </td>
+                    <td>
+                        {{ membership.role }}
+                    </td>
+                </tr>
                 {% endfor %}
-                <a href="" id="more-events"><i class="fa fa-fw fa-chevron-down"></i>Show more</a>
-                <a href="" id="fewer-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer</a>
-            {% endif %}
-        </div>
+            </tbody>
+        </table>
+
+        {% if ceo %}
+        <h4 class="mt-5"><i class="fa fa-user" aria-hidden="true"></i> Chief Executive Officer</h4>
+        <table class="table" id="ceo-table">
+            <tbody>
+                <tr>
+                    <td width="12%">
+                        <div class="thumbnail-square">
+                            <img src="{{ ceo.headshot_url }}" alt="{{ceo.name}}" title="{{ceo.name}}" class="img-responsive img-thumbnail">
+                        </div>
+                    </td>
+                    <td width="22%"><a href="{% url 'lametro:person' ceo.slug %}">{{ ceo.name }}</a></td>
+                    <td>Chief Executive Officer</td>
+                </tr>
+            </tbody>
+        </table>
+        {% endif %}
     </div>
-
-    <div class="row-fluid">
-        <div class="col-sm-12">
-        <hr />
-        </div>
-    </div>
-
-    <div class="row-fluid">
-        <div class="col-sm-8">
-
-            <h4><i class='fa fa-fw fa-group'></i> Committee Members</h4>
-            <table class='table' id='council-members'>
-                <thead>
-                    <tr>
-                        <th></th>
-                        <th>Member</th>
-                        <th>Title</th>
-                        <th class='no-wrap'>Committee Role</th>
-                    </tr>
-                </thead>
-                <tbody>
-                        {% for membership in non_ceos %}
-                            <tr>
-                                <td data-order='{{ membership.index }}'>
-                                    <div class="thumbnail-square">
-                                        <img src='{{ membership.person.headshot_url }}' alt='{{membership.person.name}}' title='{{membership.person.name}}' class='img-responsive img-thumbnail' />
-                                    </div>
-                                </td>
-                                <td>
-                                    {% if membership.person.latest_council_membership %}
-                                        <a href="{% url 'lametro:person' membership.person.slug %}">{{ membership.person.name }}</a>
-                                    {% else %}
-                                        {{ membership.person.name }}
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {{ membership.extras | clean_membership_extras }} {{ membership.person.latest_council_membership.post.label | format_label }}
-                                </td>
-                                <td>
-                                    {{ membership.role }}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                </tbody>
-            </table>
-
-            {% if ceo %}
-            <br>
-            <h4><i class="fa fa-user"></i> Chief Executive Officer</h4>
-            <table class='table' id='ceo-table'>
-                <tbody>
-                    <tr>
-                        <td width="12%">
-                            <div class="thumbnail-square">
-                                <img src='{{ ceo.headshot_url }}' alt='{{ceo.name}}' title='{{ceo.name}}' class='img-responsive img-thumbnail' />
-                            </div>
-                        </td>
-                        <td width="22%"><a href="{% url 'lametro:person' ceo.slug %}">{{ ceo.name }}</a></td>
-                        <td>Chief Executive Officer</td>
-                    </tr>
-                </tbody>
-            </table>
-            {% endif %}
-        </div>
-    </div>
+</div>
 
 {% endblock %}
 
@@ -132,7 +135,8 @@
                 null,
                 { "sType": "num-html" },
                 null
-            ]
+            ],
+            "order": []
         });
 
         $('.thumbnail-square img').each(function() {

--- a/lametro/templates/committees.html
+++ b/lametro/templates/committees.html
@@ -5,93 +5,103 @@
 {% block title %}{{CITY_COUNCIL_NAME}} Committees{% endblock %}
 {% block content %}
 
-    <div class="row-fluid">
-        <div class="col-sm-12">
-            <br class="non-mobile-only"/>
-            <h1>Metro Committees</h1>
-            <hr />
-        </div>
+<div class="row">
+    <div class="col-12">
+        <h1>Metro Committes</h1>
+        <hr aria-hidden="true">
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-8 mb-4">
+        <table class="table" id="committees">
+            <thead>
+                <tr>
+                    <th scope="col">Committee</th>
+                    <th scope="col">Chairperson(s)</th>
+                    <th scope="col">Members</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for committee in committees %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'lametro:committee' committee.slug %}">{{ committee.name | committee_topic_only }}</a>
+                        </td>
+                        <td>
+                            {% for membership in committee.chairs %}
+                                {{ membership.person.name }}
+                            {% endfor %}
+                        </td>
+                        <td>{{ committee.current_members | length }}</td>
+                    </tr>
+                {% endfor %}
+
+                {% for committee in ad_hoc_list %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'lametro:committee' committee.slug %}">{{ committee.name | committee_topic_only }}</a>
+                        </td>
+                        <td>
+                            {% for person in committee %}
+                                {% if person.role == 'Chair' %}
+                                    {{ person.9 }}
+                                {% endif %}
+                            {% endfor %}
+                        </td>
+                        <td>{{ committee | length }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
 
-    <div class="row-fluid">
-        <div class="col-sm-8 table-col">
+    <div class="col-md-4">
+        <div class="card-body info-blurb pt-3">
+            <h5 class="d-inline">
+                <i class="fa fa-fw fa-info-circle text-dark" aria-hidden="true"></i>
+                What do committees do?
+            </h5>
 
-            <div class="table-responsive">
-                <table class='table' id='committees'>
-                    <thead>
-                        <tr>
-                            <th>Committee</th>
-                            <th>Chairperson(s)</th>
-                            <th>Members</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for committee in committees %}
-                            <tr>
-                              <td align="left">
-                                    <a href="{% url 'lametro:committee' committee.slug %}">{{ committee.name | committee_topic_only }}</a>
-                                </td>
-                                <td align="left">
-                                    {% for membership in committee.chairs %}
-                                            {{ membership.person.name }}
-                                    {% endfor %}
-                                </td>
-                                <td>{{ committee.current_members | length }}</td>
-                            </tr>
-                        {% endfor %}
-                        {% for committee in ad_hoc_list %}
-                            <tr>
-                                <td align="left">
-                                    <a href="{% url 'lametro:committee' committee.slug %}">{{ committee.name | committee_topic_only }}</a></br>
-                                </td>
-                                <td align="left">
-                                    {% for person in committee %}
-                                        {% if person.role == 'Chair' %}
-                                            {{ person.9 }}
-                                        {% endif %}
-                                    {% endfor %}
-                                </td>
-                                <td>{{ committee | length }}</td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
+            {{ ABOUT_BLURBS.COMMITTEES | safe }}
 
-        <div class="col-sm-4">
-            <div class='well info-blurb'>
-                <h4><i class='fa fa-fw fa-info-circle'></i> What do committees do?</h4>
+            <p>
+                The Metro Board of Directors is currently composed of <strong>{{ committees | length }} Committees</strong>.
+                Committees set policy and discuss matters related to the transit system in Los Angeles County.
+            </p>
 
-                {{ ABOUT_BLURBS.COMMITTEES | safe }}
+            <p>
+                In addition to these committees, other entities are created by state statute, or by the Board for gathering public input in support of
+                various public purposes beyond routine monthly business. For example, the Service Authority for Freeway Emergencies (SAFE) which oversees:
+                <ol type="a">
+                    <li>the freeway callboxes and freeway service patrol tow truck services</li>
+                    <li>the Congestional Management Program (CMP) required by the State</li>
+                    <li>the Independent Citizens Advisory and Oversight Committee created by Measure R</li>
+                    <li>the Public Transportation Services Corporation (PTSC) created by the Board to facilitate the 1993 merger of the transportation commission and transit district</li>
+                    <li>the Advanced Transit Vehicle Consortium (ATVC)</li>
+                    <li>the Citizens Advisory Council (CAC) created by the State for public input on Metro's work</li>
+                    <li>the Technical Advisory Committee created by the State and its subcommittees</li>
+                    <li>the Bus Operations Subcommittee</li>
+                    <li>the Transit Demand Management/Air Quality Subcommittee</li>
+                    <li>the Streets and Freeways Subcommittee for input from our municipal operator partners and other Los Angeles County transportation program providers</li>
+                    <li>Metro's Service Councils for public input into proposes transit service changes, and others.</li>
+                </ol>
+            </p>
 
-                <p>The Metro Board of Directors is currently composed of <strong>{{ committees | length }} Committees</strong>. Committees set policy and discuss matters related to the transit system in Los Angeles County.</p>
+            <p>
+                <strong>Ad-hoc Committees</strong> are created at the Board Chair's discretion to review and discuss
+                high priority public policy matters. They may be continued, suspended, or revived by any future Board Chair.
+            </p>
 
-                <p>In addition to these committees, other entities are created by state statute, or by the Board for gathering public input in support of various public purposes beyond routine monthly business. For example, the Service Authority for Freeway Emergencies (SAFE) which oversees:
-                    <ol type="a">
-                        <li>the freeway callboxes and freeway service patrol tow truck services</li>
-                        <li>the Congestional Management Program (CMP) required by the State</li>
-                        <li>the Independent Citizens Advisory and Oversight Committee created by Measure R</li>
-                        <li>the Public Transportation Services Corporation (PTSC) created by the Board to </li>facilitate the 1993 merger of the transportation commission and transit district
-                        <li>the Advanced Transit Vehicle Consortium (ATVC)</li>
-                        <li>the Citizens Advisory Council (CAC) created by the State for public input on </li>Metro's work
-                        <li>the Technical Advisory Committee created by the State and its subcommittees</li>
-                        <li>the Bus Operations Subcommittee</li>
-                        <li>the Transit Demand Management/Air Quality Subcommittee</li>
-                        <li>the Streets and Freeways Subcommittee for input from our municipal operator </li>partners and other Los Angeles County transportation program providers
-                        <li>Metro's Service Councils for public input into proposes transit service </li>changes, and others.
-                    </ol>
-                </p>
+            <p>
+                In addition to the Board of Directors, Metro also has appointed Advisory Committees.
+                <a href="https://www.metro.net/calendar/category/committees-subcommittees/" target="_blank">Learn more about "Advisory Committees" here.</a>
+            </p>
 
-                <p><strong>Ad-hoc Committees</strong> are created at the Board Chair's discretion to review and discuss high priority public policy matters. They may be continued, suspended, or revived by any future Board Chair.</p>
-
-                <p>In addition to the Board of Directors, Metro also has appointed Advisory Committees. <a href="https://www.metro.net/calendar/category/committees-subcommittees/" target="_blank">Learn more about "Advisory Committees" here.</a></p>
-
-                <p><a href='/about/#about-la-metro'>More on how Metro works &raquo;</a></p>
-
-            </div>
+            <p><a href="/about/#about-la-metro">More on how Metro works &raquo;</a></p>
         </div>
     </div>
+</div>
 
 {% endblock %}
 {% block extra_js %}


### PR DESCRIPTION
## Overview

This continues the template upgrade to bootstrap 5, this time for the committees listing and detail pages.

Connects #969
Closes #998

## Testing Instructions
- Check the committees listing page and some detail pages against their live versions on desktop and mobile window sizes
- Confirm that
  - they look presentable/similar to the original
  - the functionality still works (table sorting, show more/fewer button, etc)