### PR TITLE
Update Google Analytics to GA4

### DIFF
--- a/configs/test_settings_deployment.py
+++ b/configs/test_settings_deployment.py
@@ -68,9 +68,6 @@ API_KEY = "test api key"
 # Set this to allow Disqus comments to render
 DISQUS_SHORTNAME = None
 
-# analytics tracking code
-ANALYTICS_TRACKING_CODE = ""
-
 HEADSHOT_PATH = os.path.join(os.path.dirname(__file__), ".." "/lametro/static/images/")
 
 SHOW_TEST_EVENTS = False

--- a/councilmatic/settings_deployment.py.example
+++ b/councilmatic/settings_deployment.py.example
@@ -65,9 +65,6 @@ API_KEY = 'test key'
 # Set this to allow Disqus comments to render
 DISQUS_SHORTNAME = None
 
-# analytics tracking code
-ANALYTICS_TRACKING_CODE = ''
-
 HEADSHOT_PATH = os.path.join(os.path.dirname(__file__), '..'
                              '/lametro/static/images/')
 

--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -3,10 +3,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <!-- Google tag (gtag.js) -->
-    <script async src=https://www.googletagmanager.com/gtag/js?id=G-9E47Y9QH06></script>
-    <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-9E47Y9QH06'); </script>
-
     <title>{% block title %}{% endblock %} - {{SITE_META.site_name}}</title>
 
     {% include '_icons.html' %}
@@ -239,10 +235,9 @@
         });
     </script>
 
-    <script>
-        var analyticsTrackingCode = '{{ANALYTICS_TRACKING_CODE}}';
-    </script>
-    <script src="{% static 'js/lib/analytics_lib.js' %}"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-9E47Y9QH06"></script>
+    <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-9E47Y9QH06'); </script>
 
 </body>
 </html>

--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -3,6 +3,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src=https://www.googletagmanager.com/gtag/js?id=G-9E47Y9QH06></script>
+    <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-9E47Y9QH06'); </script>
+
     <title>{% block title %}{% endblock %} - {{SITE_META.site_name}}</title>
 
     {% include '_icons.html' %}


### PR DESCRIPTION
## Overview

See title. This was done using the instructions on [this page that start with the header "Add the Google tag directly to your web pages"](https://support.google.com/analytics/answer/9304153?hl=en&ref_topic=9303319&sjid=17657031206868095451-NA#zippy=%2Cadd-the-google-tag-directly-to-your-web-pages).

Closes #1003

### Notes

It seems like there was a change a few years ago to [add google analytics](https://github.com/Metro-Records/la-metro-councilmatic/commit/512ca962aaab8868da441e6a3a04660d6c18d27e) but from what I've seen, that file is just for site verification, so I didn't remove it. Of course let me know if I should have!

## Testing Instructions

 * Confirm with people who have access to the google analytics account, whether or not they're receiving data in their [Realtime Report](https://support.google.com/analytics/answer/9271392)
