### PR TITLE
Refactor minutes, adjust nav and member listing slightly

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -277,6 +277,11 @@ div#toggleControls { margin-bottom: 1em; }
 .datepicker table tr td span.active.active, .datepicker table tr td span.active:hover.active {background-color: #49A6AB !important;
 }
 
+.datepicker.datepicker-dropdown{
+    border: 1px solid rgba(0,0,0,0.15);
+    box-shadow: 0 6px 12px rgba(0,0,0,0.175);
+}
+
 .btn-teal {
     background-color: #49A6AB;
     border: 1px solid #49A6AB;

--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -39,7 +39,7 @@
               <span class="navbar-toggler-icon"></span>
             </button>
             <div class="navbar-collapse collapse" id="navbarSupportedContent">
-              <ul class="navbar-nav ms-auto">
+              <ul class="navbar-nav ms-auto justify-content-end">
                 <li class="nav-item dropdown me-2 pt-3">
                   <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                     About

--- a/lametro/templates/board_members/board_members.html
+++ b/lametro/templates/board_members/board_members.html
@@ -30,7 +30,7 @@
 {% if MAP_CONFIG %}
 <div class="container-fluid" id="search-header">
     <div class="row d-flex align-center h-100">
-        <div class="col-10 offset-1 bg-transparent-white">
+        <div class="col-md-10 offset-md-1 bg-transparent-white">
             <h4 class="mt-2">Look up your Metro Board Members</h4>
 
             <div class="input-group address-search">
@@ -51,7 +51,7 @@
 </div>
 {% endif %}
 
-<div class="container-fluid mt-4 px-5">
+<div class="container-fluid mt-4 px-4 px-lg-5">
     <div class="row">
         {% if MAP_CONFIG %}
             <div class='col-lg-6 px-0 px-lg-3'>

--- a/lametro/templates/minutes/_minutes_item.html
+++ b/lametro/templates/minutes/_minutes_item.html
@@ -1,26 +1,25 @@
-{% if forloop.last %}
-<div class="row" style="margin-bottom: 30px;">
-{% else %}
 <div class="row">
-{% endif %}
-
   {% if not forloop.first %}
-    <hr class="events-line"/>
+  <div class="col-12">
+    <hr class="events-line" aria-hidden="true">
+  </div>
   {% endif %}
-  <br/>
-  <div class="col-xs-4">
-    <span class="desktop-only text-muted">
-      {{ e.meeting }}<br />
+
+  <div class="col-4">
+    <span class="text-muted">
+      {{ e.meeting }}
     </span>
   </div>
-  <div class="col-xs-4">
+
+  <div class="col-4">
     {% for link in e.agenda_link %}
-      <p><a href="{{ link | safe }}">Agenda {% if not forloop.first %}{{ forloop.counter }}{% endif %}</a><br/></p>
+      <a href="{{ link | safe }}">Agenda {% if not forloop.first %}{{ forloop.counter }}{% endif %}</a>
     {% endfor %}
   </div>
-  <div class="col-xs-4">
+
+  <div class="col-4">
     {% for link in e.minutes_link %}
-      <p><a href="{{ link | safe }}">Minutes {% if not forloop.first %}{{ forloop.counter }}{% endif %}</a><br/></p>
+      <a href="{{ link | safe }}">Minutes {% if not forloop.first %}{{ forloop.counter }}{% endif %}</a>
     {% endfor %}
   </div>
 </div>

--- a/lametro/templates/minutes/minutes.html
+++ b/lametro/templates/minutes/minutes.html
@@ -9,57 +9,53 @@
 {% endblock %}
 
 {% block content %}
-  <div class="row-fluid">
-    <div class="col-sm-9 no-pad-mobile">
-      <br/><br class="non-mobile-only"/>
-      <div id="minutes-form" class="row">
-        <div class="col-xs-8">
-          <form action='/minutes' method='GET'>
-            <div class="input-group" id='date-search'>
-              <span class="input-group-addon" id="sizing-addon3"><i class="fa fa-calendar" aria-hidden="true"></i></span>
-              <input type="text" id="minutes-from" name="minutes-from" class="form-control date-filter" placeholder="Select start date..." value='{{ start_date }}'>
-              <input type="text" id="minutes-to" name="minutes-to" class="form-control date-filter" placeholder="Select end date..." value='{{ end_date }}'>
-              <span class="input-group-btn">
-                <button class="btn btn-default btn-date" id="minutes-search" type="submit"><i class="fa fa-search" aria-hidden="true"></i> <span class='hidden-sm hidden-xs'>Search</span></button>
-              </span>
-            </div>
-          </form>
-        </div>
-        <div class="col-xs-2">
-          <a href="{% url 'lametro:minutes' %}" class="btn btn-teal d-inline-block"><i class="fa fa-repeat" aria-hidden="true"></i><span class="hidden-xs"> Reset</span></a>
-        </div>
-      </div>
-    </div>
+<div class="row mb-5" id="minutes-form">
+  <h2>Select a date range</h2>
+  <div class="col-md-8">
+      <form action='/minutes' method='GET'>
+          <div class="input-group" id='date-search'>
+              <span class="input-group-text" id="basic-addon1"><i class="fa fa-calendar" aria-hidden="true"></i></span>
+              <input type="text" id="minutes-from" name="minutes-from" class="form-control date-filter" placeholder="From..." value='{{ start_date }}' autocomplete="off">
+              <input type="text" id="minutes-to" name="minutes-to" class="form-control date-filter" placeholder="To..." value='{{ end_date }}' autocomplete="off">
+              <button class="btn btn-secondary btn-date" id="minutes-search" type="submit"><i class="fa fa-search" aria-hidden="true"></i> <span class='d-none d-sm-inline'>Search</span></button>
+          </div>
+      </form>
   </div>
-  <div class="row-fluid">
-    <div class="col-sm-9 no-pad-mobile">
-      <br/><br class="non-mobile-only"/>
-      <div id="minutes-list">
-        <h2><span>Minutes</span></h2>
-        {% for date, minutes_list in all_minutes %}
-        <div class="minutes-listing">
-          <h5 class="text-default">
-            <i class="fa fa-fw fa-calendar-o"></i> {{ date | date:"D m/d/Y"}}
-            <div class="divider"></div>
-          </h5>
-          {% for e in minutes_list %}
-            {% include 'minutes/_minutes_item.html' %}
-          {% endfor %}
-        </div>
-        {% endfor %}
-        <a href="" class="btn btn-salmon" id="more-minutes"><i class="fa fa-fw fa-chevron-down"></i>Show all minutes</a>
-        <a href="" class="btn btn-salmon" id="fewer-minutes"><i class="fa fa-fw fa-chevron-up"></i>Show fewer minutes</a>
-      </div>
-    </div>
+  <div class="col-md-4 my-2 my-md-0">
+      <a href="{% url 'lametro:minutes' %}" class="btn btn-teal d-inline-block">
+          <i class="fa fa-repeat" aria-hidden="true"></i>
+          Reset
+      </a>
   </div>
-{% endblock %}
+</div>
 
-{% if forloop.last %}
-<div class="row" style="margin-bottom: 30px;">
-{% else %}
 <div class="row">
-{% endif %}
-
+  <div class="col-md-9">
+    <div id="minutes-list">
+      <h2 class="mb-3">Minutes</h2>
+      {% if all_minutes %}
+        {% for date, minutes_list in all_minutes %}
+          <div class="minutes-listing mb-5">
+            <h5 class="text-default mb-0">
+              <i class="fa fa-fw fa-calendar-o" aria-hidden="true"></i> {{ date | date:"D m/d/Y"}}
+            </h5>
+            <div class="divider" aria-hidden="true"></div>
+            {% for e in minutes_list %}
+              {% include 'minutes/_minutes_item.html' %}
+            {% endfor %}
+          </div>
+        {% endfor %}
+        <a href="" class="btn btn-primary" id="more-minutes"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all minutes</a>
+        <a href="" class="btn btn-primary" id="fewer-minutes"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer minutes</a>
+      {% else %}
+        <div class="row my-4">
+          <h5>No minutes have been found.</h5>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}
 
 {% block extra_js %}
   <script src="{% static 'js/lib/jquery-1.10.1.min.js' %}"></script>


### PR DESCRIPTION
## Overview

This continues the template upgrade to bootstrap 5, this time for the minutes listing page. Some highlights:
- the names of the meetings are now visible on all screen sizes (as opposed to only desktop)
- a conditional to show a message for no results has been added
- the nav in the base template has been adjusted to make sure the nav-items stay to the right
- the horizontal padding in the board members' listing page has been adjusted (felt there was a little too much)

Connects #969
Closes #997

### Demo

<img width="893" alt="image" src="https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/6b76b06c-ccd2-454f-8c86-cb9a1ac88d62">


## Testing Instructions
- Check the minutes listing page against its live version on desktop and mobile window sizes
- Confirm that
  - it looks presentable/similar to the original
  - the functionality still works (date search, show all/fewer button, etc)
