### PR TITLE
Fix tag search

### DIFF
--- a/lametro/forms.py
+++ b/lametro/forms.py
@@ -12,7 +12,7 @@ from haystack.query import EmptySearchQuerySet
 
 from councilmatic_core.views import CouncilmaticSearchForm
 
-from lametro.models import LAMetroBill, LAMetroPerson
+from lametro.models import LAMetroPerson
 
 
 class LAMetroCouncilmaticSearchForm(CouncilmaticSearchForm):

--- a/lametro/forms.py
+++ b/lametro/forms.py
@@ -2,7 +2,6 @@ import requests
 
 from django import forms
 from django.core.files.uploadedfile import InMemoryUploadedFile
-from django.db.models import Q
 
 from captcha.fields import ReCaptchaField
 from captcha.fields import ReCaptchaV3

--- a/lametro/forms.py
+++ b/lametro/forms.py
@@ -49,7 +49,7 @@ class LAMetroCouncilmaticSearchForm(CouncilmaticSearchForm):
         report_filter = SQ()
         attachment_filter = SQ()
 
-        for token in self.cleaned_data["q"].split(" AND "):
+        for token in self.cleaned_data["q"].split(" and "):
             report_filter &= SQ(text=Raw(token))
             attachment_filter &= SQ(attachment_text=Raw(token))
 
@@ -63,24 +63,15 @@ class LAMetroCouncilmaticSearchForm(CouncilmaticSearchForm):
     def _topic_search(self, sqs):
         terms = [
             term.strip().replace('"', "")
-            for term in self.cleaned_data["q"].split(" AND ")
+            for term in self.cleaned_data["q"].split(" and ")
             if term
         ]
 
-        topic_filter = Q()
-
+        topic_filter = SQ()
         for term in terms:
-            topic_filter |= Q(subject__icontains=term)
+            topic_filter &= SQ(topics__in=[term])
 
-        tagged_results = LAMetroBill.objects.filter(topic_filter).values_list(
-            "id", flat=True
-        )
-
-        if self.result_type == "keyword":
-            sqs = sqs.exclude(id__in=tagged_results)
-
-        elif self.result_type == "topic":
-            sqs = sqs.filter(id__in=tagged_results)
+        sqs = sqs.filter(topic_filter)
 
         return sqs
 
@@ -93,8 +84,11 @@ class LAMetroCouncilmaticSearchForm(CouncilmaticSearchForm):
         has_query = hasattr(self, "cleaned_data") and self.cleaned_data["q"]
 
         if has_query:
-            sqs = self._full_text_search(sqs)
-            sqs = self._topic_search(sqs)
+            if self.result_type == "keyword":
+                sqs = self._full_text_search(sqs)
+
+            if self.result_type == "topic":
+                sqs = self._topic_search(sqs)
 
         return sqs
 


### PR DESCRIPTION
## Overview

This PR fixes two tag search bugs:

1. Searches for multiple tags yielding no results
2. Searches for tags with many associated board reports error-ing out (e.g. `project`)

Connects #1011 
Connects #972 

## Testing Instructions

 * Make sure your local instance has enough board reports (maybe 100+?)
 * Navigate to the search page
 * Execute two tag separate tag searches (e.g. `budget` then `accounting`)
 * Search for the same two tags together (e.g. `budget` and `accounting`)
 * Verify that searching multiple tags yields only board reports with *all* searched tags
 * Verify that full text and normal search still works as expected

 * Verify that tag searches for common tags like `project` don't error out. Locally, you can verify that the search query in the terminal doesn't look like this: 
<img width="720" alt="Screen Shot 2023-10-02 at 2 30 47 PM" src="https://github.com/Metro-Records/la-metro-councilmatic/assets/36973363/8bafd9fb-a0f4-4368-b647-706122b104ef">

I'll verify this behavior on staging as well.
