### PR TITLE
Add bill type matches to tag search results

### DIFF
--- a/lametro/forms.py
+++ b/lametro/forms.py
@@ -67,10 +67,12 @@ class LAMetroCouncilmaticSearchForm(CouncilmaticSearchForm):
         ]
 
         topic_filter = SQ()
+        bill_type_filter = SQ()
         for term in terms:
             topic_filter &= SQ(topics__in=[term])
+            bill_type_filter &= SQ(bill_type__icontains=term)
 
-        sqs = sqs.filter(topic_filter)
+        sqs = sqs.filter(topic_filter | bill_type_filter)
 
         return sqs
 
@@ -85,9 +87,11 @@ class LAMetroCouncilmaticSearchForm(CouncilmaticSearchForm):
         if has_query:
             if self.result_type == "keyword":
                 sqs = self._full_text_search(sqs)
-
-            if self.result_type == "topic":
+            elif self.result_type == "topic":
                 sqs = self._topic_search(sqs)
+            else:
+                # Combine full text and tag search results
+                sqs = self._full_text_search(sqs) | self._topic_search(sqs)
 
         return sqs
 

--- a/lametro/forms.py
+++ b/lametro/forms.py
@@ -67,12 +67,10 @@ class LAMetroCouncilmaticSearchForm(CouncilmaticSearchForm):
         ]
 
         topic_filter = SQ()
-        bill_type_filter = SQ()
         for term in terms:
-            topic_filter &= SQ(topics__in=[term])
-            bill_type_filter &= SQ(bill_type__icontains=term)
+            topic_filter &= SQ(topics__in=[term]) | SQ(bill_type__in=[term])
 
-        sqs = sqs.filter(topic_filter | bill_type_filter)
+        sqs = sqs.filter(topic_filter)
 
         return sqs
 

--- a/lametro/forms.py
+++ b/lametro/forms.py
@@ -68,7 +68,18 @@ class LAMetroCouncilmaticSearchForm(CouncilmaticSearchForm):
 
         topic_filter = SQ()
         for term in terms:
-            topic_filter &= SQ(topics__in=[term]) | SQ(bill_type__in=[term])
+            topic_filter &= (
+                SQ(topics__in=[term])
+                | SQ(bill_type__in=[term])
+                | SQ(lines_and_ways__in=[term])
+                | SQ(phase__in=[term])
+                | SQ(project__in=[term])
+                | SQ(metro_location__in=[term])
+                | SQ(geo_admin_location__in=[term])
+                | SQ(significant_date__in=[term])
+                | SQ(motion_by__in=[term])
+                | SQ(plan_program_policy__in=[term])
+            )
 
         sqs = sqs.filter(topic_filter)
 


### PR DESCRIPTION
## Overview

See title.

Connects #1026 

## Notes

The tags displayed below a search result:

<img width="906" alt="Screen Shot 2023-10-04 at 1 10 44 PM" src="https://github.com/Metro-Records/la-metro-councilmatic/assets/36973363/8d9107a1-768b-4935-afb1-7c375c87c8f3">

include not only formal "topics" but also locations, programs, policies, bill types, etc. 

I think it would be a good idea to match users' tag searches over all of those values. We could add a combined `tags` field to the search index to easily query tags with `sqs.filter(tags__in=[search_term])`.

## Testing Instructions

 * Search for a bill type (e.g. `Informational Report`)
 * Click `Tag search`
 * Verify that this yields all matching bill types
 * Verify that a tag search for a topic and a bill type works as expected