### PR TITLE
Add 'phrase in quotes' help text to search bar

### DIFF
--- a/lametro/static/js/autocomplete.js
+++ b/lametro/static/js/autocomplete.js
@@ -81,7 +81,7 @@ function initAutocomplete (formElement, inputElement) {
 
     $input.select2({
         tags: true,
-        placeholder: 'Search for a phrase using "double quotes"',
+        placeholder: 'Search for a keyword or use "double quotes" to search for a phrase',
         ajax: {
             url: SmartLogic.buildServiceUrl,
             headers: {

--- a/lametro/static/js/autocomplete.js
+++ b/lametro/static/js/autocomplete.js
@@ -81,6 +81,7 @@ function initAutocomplete (formElement, inputElement) {
 
     $input.select2({
         tags: true,
+        placeholder: 'Search for a phrase using "double quotes"',
         ajax: {
             url: SmartLogic.buildServiceUrl,
             headers: {


### PR DESCRIPTION
## Overview

Quick adjustment to add the placeholder text 'Search for a phrase using "double quotes"' to the search bars

- Closes #1013

### Demo

![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/e2d59dee-ff86-430c-a353-eb4573fe9cb0)

## Testing Instructions

 * Confirm that it displays properly on the search bar
 * Decide if the language used is clear
