### PR TITLE
Fix search suggestions

### DIFF
--- a/lametro/static/js/autocomplete.js
+++ b/lametro/static/js/autocomplete.js
@@ -1,267 +1,288 @@
 var SmartLogic = {
   query: {},
-  getToken: function () {
+  getToken: function() {
     tokenNeeded = !window.localStorage.getItem('ses_token')
 
     msInDay = 86400000
-    tokenExpired = (Date.now() - window.localStorage.getItem('ses_issued')) / msInDay >= 3
+    tokenExpired =
+      (Date.now() - window.localStorage.getItem('ses_issued')) / msInDay >= 3
 
-    if ( (tokenNeeded || tokenExpired) ) {
-      return $.get(
-        '/smartlogic/token/'
-      ).then(function(response) {
-          window.localStorage.setItem('ses_token', response.access_token);
-          window.localStorage.setItem('ses_issued', Date.now());
-      }).fail(function() {
-          console.error('Failed to retrieve SES API token. Autocomplete is disabled.');
-      });
-    };
+    if (tokenNeeded || tokenExpired) {
+      return $.get('/smartlogic/token/')
+        .then(function(response) {
+          window.localStorage.setItem('ses_token', response.access_token)
+          window.localStorage.setItem('ses_issued', Date.now())
+        })
+        .fail(function() {
+          console.error(
+            'Failed to retrieve SES API token. Autocomplete is disabled.'
+          )
+        })
+    }
   },
-  buildServiceUrl: function (query) {
+  buildServiceUrl: function(query) {
     // Remove slashes from term, as not to confuse routing
     var sanitizedTerm = query.term.replaceAll('/', ' ')
-    var action = query.action ? query.action : 'suggest';
-    var stop = query.stop_cm_after_stage ? query.stop_cm_after_stage : '3';
-    var maxResults = query.maxResultCount ? query.maxResultCount : '10';
+    var action = query.action ? query.action : 'suggest'
+    var stop = query.stop_cm_after_stage ? query.stop_cm_after_stage : '3'
+    var maxResults = query.maxResultCount ? query.maxResultCount : '10'
 
-    return '/smartlogic/concepts/' + sanitizedTerm + '/' + action
-        + '?stop_cm_after_stage=' + stop
-        + '&maxResultCount=' + maxResults
-        + '&FILTER=AT=System:%20Legistar';
+    return (
+      '/smartlogic/concepts/' +
+      sanitizedTerm +
+      '/' +
+      action +
+      '?stop_cm_after_stage=' +
+      stop +
+      '&maxResultCount=' +
+      maxResults +
+      '&FILTER=AT=System:%20Legistar'
+    )
   },
-  transformResponse: function (data, params) {
-    SmartLogic.query = params;
+  transformResponse: function(data, params) {
+    SmartLogic.query = params
 
     var results = $.map(data.subjects, function(result) {
-        return {text: result.display_name, id: result.name}
-    });
+      return { text: result.display_name, id: result.name }
+    })
 
     // Only show the suggested group if there are suggestions
-    var groupedResults = results.length > 0
-      ? [{
-        'text': 'Suggested query terms',
-        'children': results
-      }]
-      : [];
+    var groupedResults =
+      results.length > 0
+        ? [
+          {
+            text: 'Suggested query terms',
+            children: results,
+          },
+        ]
+        : []
 
     return {
-      'results': groupedResults,
-      'pagination': {'more': false}
-    };
+      results: groupedResults,
+      pagination: { more: false },
+    }
   },
-  highlightResult: function (result) {
+  highlightResult: function(result) {
     // Return the first result with a set prefix, no highlight
-    if ( result.newTag === true ) {
+    if (result.newTag === true) {
       return $('<span></span>')
         .append('<strong>What you typed: </strong>' + result.text)
         .attr('data-name', result.id)
-    };
-
-    var term = SmartLogic.query.term.trim();
-
-    var escapeRegex = function (string) {
-      return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
     }
 
-    var match = new RegExp('(' + escapeRegex(term) + ')', "ig");
-    var highlightedResult = result.text.replace(match, '<strong class="match-group">$1</strong>');
+    var term = SmartLogic.query.term.trim()
+
+    var escapeRegex = function(string) {
+      return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+    }
+
+    var match = new RegExp('(' + escapeRegex(term) + ')', 'ig')
+    var highlightedResult = result.text.replace(
+      match,
+      '<strong class="match-group">$1</strong>'
+    )
 
     return $('<span></span>')
       .append(highlightedResult)
-      .attr('data-name', result.id);
-  }
-};
+      .attr('data-name', result.id)
+  },
+}
 
-function initAutocomplete (formElement, inputElement) {
-    var $form = $(formElement);
-    var $input = $(inputElement);
-    var currentQuery;
+function initAutocomplete(formElement, inputElement) {
+  var $form = $(formElement)
+  var $input = $(inputElement)
+  var currentQuery
 
-    SmartLogic.getToken();
+  SmartLogic.getToken()
 
-    $input.select2({
-        tags: true,
-        ajax: {
-            url: SmartLogic.buildServiceUrl,
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-                'Authorization': 'Bearer ' + window.localStorage.getItem('ses_token')
-            },
-            processResults: SmartLogic.transformResponse
+  $input
+    .select2({
+      tags: true,
+      ajax: {
+        url: SmartLogic.buildServiceUrl,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: 'Bearer ' + window.localStorage.getItem('ses_token'),
         },
-        templateResult: function (state) {
-          return state.loading
-            ? state.text
-            : SmartLogic.highlightResult(state);
+        processResults: SmartLogic.transformResponse,
+      },
+      templateResult: function(state) {
+        return state.loading ? state.text : SmartLogic.highlightResult(state)
+      },
+      containerCssClass: 'input-lg form-control form-lg autocomplete-search',
+      minimumInputLength: 3,
+      language: {
+        inputTooShort: function(args) {
+          return 'Enter 3 or more characters to view suggestions.'
         },
-        containerCssClass: 'input-lg form-control form-lg autocomplete-search',
-        minimumInputLength: 3,
-        language: {
-          inputTooShort: function (args) {
-            return 'Enter 3 or more characters to view suggestions.'
-          }
-        },
-        createTag: function (params) {
-          var term = $.trim(params.term);
+      },
+      createTag: function(params) {
+        var term = $.trim(params.term)
 
-          if (term === '') {
-            return null;
-          }
-
-          return {
-            id: term,
-            text: term,
-            newTag: true
-          }
+        if (term === '') {
+          return null
         }
-    }).on('select2:closing', function(e) {
-        /* By default, Select2 clears input when the user clicks inside the
+
+        return {
+          id: term,
+          text: term,
+          newTag: true,
+        }
+      },
+    })
+    .on('select2:closing', function(e) {
+      /* By default, Select2 clears input when the user clicks inside the
            search bar or the input loses focus. We want to retain that input.
            I adapted this solution from this comment:
            https://github.com/select2/select2/issues/3902#issuecomment-206658823 */
 
-        // Grab the input value before closing the menu.
-        currentQuery = $('.select2-search input').prop('value');
-    }).on('select2:close', function(e) {
-        // Once the menu has closed, add back the input value.
-        $('.select2-search input').val(currentQuery).trigger('change');
-    }).on('select2:open', function(e) {
-        // When the menu reopens (or regains focus), initialize a search with
-        // the input value.
-        $('.select2-search input').trigger('input');
-    }).on('select2:select', function(e) {
-        // When a user selects a value, clear the existing input value. (This
-        // basically preserves normal select behavior with the above measures
-        // to preserve pending input between selections.)
-        $('.select2-search input').val('').trigger('change');
-    });
-
-    function handleSubmit(e) {
-        var terms = $('#search-bar')
-          .select2('data')
-          .map(function (el) {return el.id});
-
-        // Grab the input text
-        var pendingTerm = $('.select2-search input').prop('value');
-
-        // If there's a pending term, add it to the query
-        if ( pendingTerm !== '' ) {
-          terms.push(pendingTerm);
-        };
-
-        var queryString = terms.join(' AND ');
-
-        var corpusString = $(e.target).find('input[name="search-all"]')[0].checked
-          ? 'search-all=on'
-          : 'search-reports=on';
-
-        var extraParams = [];
-
-        $.each($(e.target).find('input[type="hidden"]'), function (_, el) {
-          var param = $(el).attr('name') + '=' + $(el).attr('value');
-          extraParams.push(param);
-        });
-
-        var searchUrl = '/search/?q=' + queryString + '&' + corpusString;
-
-        if ( extraParams.length > 0 ) {
-          extraParamString = extraParams.join('&');
-          searchUrl = searchUrl + '&' + extraParamString;
-        };
-
-        window.location.href = searchUrl;
-    };
-
-    // Store handleSubmit in the global namespace so it can be referenced in
-    // the reCAPTCHA callback
-    window.handleSubmit = handleSubmit;
-
-    // Select option and execute search on enter
-    // https://github.com/select2/select2/issues/1456#issuecomment-265457102
-    var submitOnEnter = function (e) {
-        if (e.keyCode === 13) {
-          $form.submit();
-        }
-    };
-
-    $input.on('select2:select', function (e) {
-        $form.off('keyup', '.select2-selection', submitOnEnter);
-    });
-
-    $input.on('select2:opening', function (e) {
-        $form.on('keyup', '.select2-selection', submitOnEnter);
-    });
-}
-
-function showRelatedTerms (termArray) {
-    if ( termArray.length === 0 ) {
-        return;
-    };
-
-    // Execute all Ajax requests before proceeding:
-    // https://stackoverflow.com/a/5627301/7142170
-    $.when.apply(
-        $, termArray.map(getRelatedTerms)
-    ).then(function () {
-        // arguments is a magic variable containing all arguments passed to
-        // this function. This is helpful, because we have an indeterminate
-        // number of Ajax requests to deal with.
-        //
-        // If there is only one request, then args is an array with three items:
-        // the response, status, and Ajax object. If there is more than one,
-        // then args is an array of these arrays.
-        var relatedTerms = [];
-
-        if ( termArray.length === 1 ) {
-            var response = arguments[0];
-            relatedTerms = parseRelatedTerms(response);
-        } else {
-            $.each(arguments, function (_, arg) {
-                var response = arg[0];
-                relatedTerms = relatedTerms.concat(parseRelatedTerms(response));
-            });
-        };
-
-        renderRelatedTerms(relatedTerms);
+      // Grab the input value before closing the menu.
+      currentQuery = $('.select2-search input').prop('value')
     })
-}
+    .on('select2:close', function(e) {
+      // Once the menu has closed, add back the input value.
+      $('.select2-search input').val(currentQuery).trigger('change')
+    })
+    .on('select2:open', function(e) {
+      // When the menu reopens (or regains focus), initialize a search with
+      // the input value.
+      $('.select2-search input').trigger('input')
+    })
+    .on('select2:select', function(e) {
+      // When a user selects a value, clear the existing input value. (This
+      // basically preserves normal select behavior with the above measures
+      // to preserve pending input between selections.)
+      $('.select2-search input').val('').trigger('change')
+    })
 
-function getRelatedTerms (term) {
-    console.log('Retrieving terms related to ' + term);
+  function handleSubmit(e) {
+    var terms = $('#search-bar')
+      .select2('data')
+      .map(function(el) {
+        return el.id
+      })
 
-    var url = SmartLogic.buildServiceUrl({
-        'term': term,
-        'action': 'relate',
-        'stop_cm_after_stage': 1,
-        'maxResultCount': 5,
-    });
+    // Grab the input text
+    var pendingTerm = $('.select2-search input').prop('value')
 
-    return $.ajax({
-        url: url,
-        headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'Authorization': 'Bearer ' + window.localStorage.getItem('ses_token')
-        }
-    });
-}
-
-function parseRelatedTerms (response) {
-    if ( response.status_code == 200 && response.subjects.length > 0) {
-        return $.map(response.subjects, function (subject) {
-            return subject.name
-        });
-    } else {
-        return [];
-    };
-}
-
-function renderRelatedTerms (subjects) {
-    if ( subjects.length > 0 ) {
-        $('#related-terms').removeClass('hidden');
-
-        $.each(subjects, function (idx, subject) {
-            var link = $('<a />').attr('href', '/search/?q=' + subject).text(subject);
-            $('#related-terms').append(link).append('<br />');
-        });
+    // If there's a pending term, add it to the query
+    if (pendingTerm !== '') {
+      terms.push(pendingTerm)
     }
+
+    var queryString = terms.join(' AND ')
+
+    var corpusString = $(e.target).find('input[name="search-all"]')[0].checked
+      ? 'search-all=on'
+      : 'search-reports=on'
+
+    var extraParams = []
+
+    $.each($(e.target).find('input[type="hidden"]'), function(_, el) {
+      var param = $(el).attr('name') + '=' + $(el).attr('value')
+      extraParams.push(param)
+    })
+
+    var searchUrl = '/search/?q=' + queryString + '&' + corpusString
+
+    if (extraParams.length > 0) {
+      extraParamString = extraParams.join('&')
+      searchUrl = searchUrl + '&' + extraParamString
+    }
+
+    window.location.href = searchUrl
+  }
+
+  // Store handleSubmit in the global namespace so it can be referenced in
+  // the reCAPTCHA callback
+  window.handleSubmit = handleSubmit
+
+  // Select option and execute search on enter
+  // https://github.com/select2/select2/issues/1456#issuecomment-265457102
+  var submitOnEnter = function(e) {
+    if (e.keyCode === 13) {
+      $form.submit()
+    }
+  }
+
+  $input.on('select2:select', function(e) {
+    $form.off('keyup', '.select2-selection', submitOnEnter)
+  })
+
+  $input.on('select2:opening', function(e) {
+    $form.on('keyup', '.select2-selection', submitOnEnter)
+  })
+}
+
+function showRelatedTerms(termArray) {
+  if (termArray.length === 0) {
+    return
+  }
+
+  // Execute all Ajax requests before proceeding:
+  // https://stackoverflow.com/a/5627301/7142170
+  $.when.apply($, termArray.map(getRelatedTerms)).then(function() {
+    // arguments is a magic variable containing all arguments passed to
+    // this function. This is helpful, because we have an indeterminate
+    // number of Ajax requests to deal with.
+    //
+    // If there is only one request, then args is an array with three items:
+    // the response, status, and Ajax object. If there is more than one,
+    // then args is an array of these arrays.
+    var relatedTerms = []
+
+    if (termArray.length === 1) {
+      var response = arguments[0]
+      relatedTerms = parseRelatedTerms(response)
+    } else {
+      $.each(arguments, function(_, arg) {
+        var response = arg[0]
+        relatedTerms = relatedTerms.concat(parseRelatedTerms(response))
+      })
+    }
+
+    renderRelatedTerms(relatedTerms)
+  })
+}
+
+function getRelatedTerms(term) {
+  console.log('Retrieving terms related to ' + term)
+
+  var url = SmartLogic.buildServiceUrl({
+    term: term,
+    action: 'relate',
+    stop_cm_after_stage: 1,
+    maxResultCount: 5,
+  })
+
+  return $.ajax({
+    url: url,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: 'Bearer ' + window.localStorage.getItem('ses_token'),
+    },
+  })
+}
+
+function parseRelatedTerms(response) {
+  if (response.status_code == 200 && response.subjects.length > 0) {
+    return $.map(response.subjects, function(subject) {
+      return subject.name
+    })
+  } else {
+    return []
+  }
+}
+
+function renderRelatedTerms(subjects) {
+  if (subjects.length > 0) {
+    $('#related-terms').removeClass('hidden')
+
+    $.each(subjects, function(idx, subject) {
+      var link = $('<a />')
+        .attr('href', '/search/?q=' + subject)
+        .text(subject)
+      $('#related-terms').append(link).append('<br />')
+    })
+  }
 }


### PR DESCRIPTION
## Overview

This PR fixes a bug where search suggestions were not loading correctly. 

Connects #1030

### Issue summary

When a new visitor loads the page we request a Smartlogic token for them. However, we weren't waiting for the token to be granted and stored before setting up the search bar, causing a 403 error whenever it tried to get suggestions. The token was fetched after the bar had been configured.

On subsequent page loads, the search suggestions functioned as expected since the token was already stored in the browser.

## Testing Instructions

 * Either open a private window or clear your browser's cookies/cache (note that in some browsers, e.g. Firefox, browser data persists across open private tabs)
 * Navigate to the homepage
 * Verify that you are able to load search suggestions
