### PR TITLE
Remove RSS link from search results

### DIFF
--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -201,20 +201,7 @@
 
             {% if query or selected_facets %}
             <h3 class="modal-links">
-
                 {% include 'search/_search_results_header.html' %}
-
-                <small>
-                    {% if query and selected_facets %}
-                        <a href="/search/rss/?q={{request.GET.q}}{% for key, values in selected_facets.items %}{% for value in values %}&selected_facets={{key}}:{{value}}{% endfor %}{% endfor %}" title="RSS feed">
-                    {% elif selected_facets %}
-                        <a href="/search/rss/?{% for key, values in selected_facets.items %}{% for value in values %}&selected_facets={{key}}:{{value}}{% endfor %}{% endfor %}" title="RSS feed">
-                    {% else %}
-                        <a href="/search/rss/?q={{request.GET.q}}" title="RSS feed">
-                    {% endif %}
-
-                    <i class="fa fa-rss-square" aria-hidden="true"></i></a>
-                </small>
             </h3>
             <div class='row'>
                 <div class='col-sm-8' id='search_message'></div>


### PR DESCRIPTION
## Overview

See title

Connects #51 

### Demo

<img width="906" alt="Screen Shot 2023-10-24 at 10 02 50 AM" src="https://github.com/Metro-Records/la-metro-councilmatic/assets/36973363/8c96f1e3-f38b-42ee-bd71-2696f3be35f0">

## Testing Instructions

 * Verify that the RSS icon/link has been removed from search pages
