### PR TITLE
Add alerts to the admin

### DIFF
--- a/lametro/admin.py
+++ b/lametro/admin.py
@@ -1,0 +1,9 @@
+from django.contrib import admin  # noqa
+from lametro.models import Alert
+
+
+class AlertAdmin(admin.ModelAdmin):
+    list_display = ("type", "description")
+
+
+admin.site.register(Alert, AlertAdmin)


### PR DESCRIPTION
## Overview

This is a quick fix for the error that they're having described in #1036 at time of writing. I'll continue figuring out why alerts aren't showing in the manager for a more definite fix.

Being able to see the alerts in the admin might help in debugging the live site as well.

### Demo

![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/cb012a93-88b2-4721-8fa9-7364e832360d)

## Testing Instructions

 * Log in and add an alert, confirming that it displays on the site
 * Navigate to the admin and delete it from there
 * Confirm that it no longer displays on the site
