### PR TITLE
Move alert rendering outside of the navigation cache

### DIFF
--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -1,4 +1,4 @@
-{% load adv_cache static %}
+{% load adv_cache extras lametro_extras markdownify static %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -99,9 +99,8 @@
             </div><!-- /.navbar-collapse -->
         </div>
     </nav>
+    {% endcache %}
 
-    {% load extras lametro_extras static %}
-    {% load markdownify %}
     {% get_alerts as alerts %}
     {% if alerts %}
         {% for alert in alerts %}
@@ -110,8 +109,6 @@
             </div>
         {% endfor %}
     {% endif %}
-
-    {% endcache %}
 
     {% block full_content %}
     {% endblock %}


### PR DESCRIPTION
## Overview

See title. This change enables realtime updating of alerts, which were previously not rendering immediately on the live site due to cache interference.

Connects #1036 

### Demo

![alerts](https://github.com/Metro-Records/la-metro-councilmatic/assets/12176173/bb9674a7-dad6-4913-b14d-b7180a15e979)

### Notes

This project uses a special caching library that allows you to cache fragments of a template. (This feature has since become native to Django; our use of the library predates this change.) 

In order to cache template fragments, you wrap sections of HTML in the `{% cache ...options %}{% endcache %}` tag.

This bug was a result of retrieving the value of `alerts` and rendering alerts within the cached navigation block. By moving the call to `get_alerts` and display of existing alerts outside of the tag, alerts now update in realtime.

## Testing Instructions

 * Update the CACHES setting in your local settings_deployment.py file to:
 ```python
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.db.DatabaseCache",
         "LOCATION": "councilmatic_cache",
     }
 }
 ```
 * Create a superuser in your local instance: `docker-compose run --rm app python manage.py createsuperuser`
 * Log in to your local instance at http://localhost:8001/metro-login
 * Navigate back to the homepage and create some alerts. Confirm they show up on page load at the top of the page and in the alert manager.
 * Delete some alerts and confirm they are removed from the top of the page and the alert manager.
