### PR TITLE
Add caltrans description to board members map tooltip

### DIFF
--- a/lametro/templates/board_members/board_members.html
+++ b/lametro/templates/board_members/board_members.html
@@ -71,13 +71,13 @@
                     <input type="radio" name="options" autocomplete="off"> City of LA
                   </label>
                   <label id="caltransToggle" class="btn btn-xs btn-caltrans">
-                    <input type="radio" name="options" autocomplete="off"> CalTrans
+                    <input type="radio" name="options" autocomplete="off"> Caltrans
                   </label>
                   <a tabindex="0" class="map-info" data-container="body" data-toggle="popover" data-placement="right" title="What do these map layers represent?" data-content="<p style='font-family: &quot;Open Sans&quot;, sans-serif; font-size: 14px;'>The three layers of this map show areas from which members of the Metro Board of Directors are nominated:<br><br>
                     <strong>(1) Los Angeles County Districts</strong> – The elected representative from each district from the Los Angeles County Board of Supervisors serves on the Metro Board.<br><br>
                     <strong>(2) Sectors</strong> – As defined by the California League of Cities, all the incorporated and unincorporated areas in Los Angeles County, excluding the City of Los Angeles, are divided into four sectors. Each sector nominates one representative, which is approved and appointed by all members of the California League of Cities, to serve on the Metro Board.<br><br>
                     <strong>(3) City of Los Angeles</strong> – Residents within the City of Los Angeles are represented by the mayor and three city appointees on the Metro Board.<br><br>
-                    <strong>(4) CalTrans District 7</strong> - The Governor of California appoints a non-voting member to the Metro Board. The California Department of Transportation (CalTrans) District 7 Director is the current appointee. CalTrans District 7 includes Los Angeles and Ventura counties.<br><br>
+                    <strong>(4) Caltrans District 7</strong> - The Governor of California appoints a non-voting member to the Metro Board. The California Department of Transportation (Caltrans) District 7 Director is the current appointee. Caltrans District 7 includes Los Angeles and Ventura counties.<br><br>
                     Learn more about <a href='{% url 'about' %}#about-la-metro'>Metro Board appointments</a>.</p>"><h3 class="no-pad-top"><small> <i class="fa fa-info-circle" aria-hidden="true"></i> Learn more</small></h3></a>
                 </div>
 

--- a/lametro/templates/board_members/board_members.html
+++ b/lametro/templates/board_members/board_members.html
@@ -71,13 +71,13 @@
                     <input type="radio" name="options" autocomplete="off"> City of LA
                   </label>
                   <label id="caltransToggle" class="btn btn-xs btn-caltrans">
-                    <input type="radio" name="options" autocomplete="off"> Caltrans
+                    <input type="radio" name="options" autocomplete="off"> CalTrans
                   </label>
                   <a tabindex="0" class="map-info" data-container="body" data-toggle="popover" data-placement="right" title="What do these map layers represent?" data-content="<p style='font-family: &quot;Open Sans&quot;, sans-serif; font-size: 14px;'>The three layers of this map show areas from which members of the Metro Board of Directors are nominated:<br><br>
                     <strong>(1) Los Angeles County Districts</strong> – The elected representative from each district from the Los Angeles County Board of Supervisors serves on the Metro Board.<br><br>
                     <strong>(2) Sectors</strong> – As defined by the California League of Cities, all the incorporated and unincorporated areas in Los Angeles County, excluding the City of Los Angeles, are divided into four sectors. Each sector nominates one representative, which is approved and appointed by all members of the California League of Cities, to serve on the Metro Board.<br><br>
                     <strong>(3) City of Los Angeles</strong> – Residents within the City of Los Angeles are represented by the mayor and three city appointees on the Metro Board.<br><br>
-                    <strong>(4) CalTrans District 7</strong> - The Governor of California appoints a non-voting member to the Metro Board. The California Department of Transportation (Caltrans) District 7 Director is the current appointee. CalTrans District 7 includes Los Angeles and Ventura counties.<br><br>
+                    <strong>(4) CalTrans District 7</strong> - The Governor of California appoints a non-voting member to the Metro Board. The California Department of Transportation (CalTrans) District 7 Director is the current appointee. CalTrans District 7 includes Los Angeles and Ventura counties.<br><br>
                     Learn more about <a href='{% url 'about' %}#about-la-metro'>Metro Board appointments</a>.</p>"><h3 class="no-pad-top"><small> <i class="fa fa-info-circle" aria-hidden="true"></i> Learn more</small></h3></a>
                 </div>
 

--- a/lametro/templates/board_members/board_members.html
+++ b/lametro/templates/board_members/board_members.html
@@ -77,6 +77,7 @@
                     <strong>(1) Los Angeles County Districts</strong> – The elected representative from each district from the Los Angeles County Board of Supervisors serves on the Metro Board.<br><br>
                     <strong>(2) Sectors</strong> – As defined by the California League of Cities, all the incorporated and unincorporated areas in Los Angeles County, excluding the City of Los Angeles, are divided into four sectors. Each sector nominates one representative, which is approved and appointed by all members of the California League of Cities, to serve on the Metro Board.<br><br>
                     <strong>(3) City of Los Angeles</strong> – Residents within the City of Los Angeles are represented by the mayor and three city appointees on the Metro Board.<br><br>
+                    <strong>(4) CalTrans District 7</strong> - The Governor of California appoints a non-voting member to the Metro Board. The California Department of Transportation (Caltrans) District 7 Director is the current appointee. CalTrans District 7 includes Los Angeles and Ventura counties.<br><br>
                     Learn more about <a href='{% url 'about' %}#about-la-metro'>Metro Board appointments</a>.</p>"><h3 class="no-pad-top"><small> <i class="fa fa-info-circle" aria-hidden="true"></i> Learn more</small></h3></a>
                 </div>
 
@@ -85,7 +86,7 @@
                 <div id="map"></div>
             </div>
             <div class="col-sm-6 no-pad-mobile">
-              
+
                     {% include 'board_members/_council_member_table.html' %}
             </div>
         {% else %}


### PR DESCRIPTION
## Overview

See title

- Connects #1038

### Demo

![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/9ff5a076-f06c-4a4f-8514-7136a759672e)

## Testing Instructions

 * Click the tooltip above the map on the board members listing page
 * Confirm that the new CalTrans description displays
