### PR TITLE
A11y Improvements - Perceivable

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -755,3 +755,8 @@ a, .btn-link, .page-link {
 .btn-secondary {
     background-color: #6C757D;
 }
+
+.search-results {
+    list-style: none;
+    padding-left: 0px;
+}

--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -5,7 +5,7 @@ body, h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6, .navbar {
 }
 
 body, body .table, .popover-body, .badge-facet, .text-body-secondary {
-    color: #777777;
+    color: #6B6B6B;
 }
 
 h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6, .navbar, th {
@@ -198,10 +198,10 @@ strong.match-group {
   background-color: #EB6864;
 }
 
-.label-teal { background-color: #49A6AB; }
+.label-teal { background-color: #0E8389; }
 
 .label-received, .label-approved, .label-adopted {
-    background-color: #1D9A43;
+    background-color: #008027;
 }
 
 .label-active {
@@ -221,6 +221,7 @@ strong.match-group {
     margin-left: 1.8em;
     padding-top: 5px;
     padding-bottom: 5px;
+    color: #B82A25;
 }
 
 .nav-inline {
@@ -264,11 +265,11 @@ div.order-nav { margin-top: 21px; }
 
 div#toggleControls { margin-bottom: 1em; }
 
-.badge.district-badge { background-color: #3D8A8E; }
+.badge.district-badge { background-color: #27777B; }
 
 .badge.sector-badge { background-color: #4D649E; }
 
-.badge.city-badge { background-color: #EB6864; }
+.badge.city-badge { background-color: #C7403B; }
 
 .badge.caltrans-badge { background-color: #E5B761; color: #000; }
 
@@ -299,8 +300,8 @@ div#toggleControls { margin-bottom: 1em; }
 }
 
 .btn-teal {
-    background-color: #49A6AB;
-    border: 1px solid #49A6AB;
+    background-color: #0E8389;
+    border: 1px solid #0E8389;
     color: #fff;
 }
 
@@ -546,7 +547,7 @@ hr .events-line {
     border-color: white;
 }
 
-.nav-link:hover, .nav-link:active, .nav-link:focus, a, .btn-link {
+.nav-link:hover, .nav-link:active, .nav-link:focus {
     text-decoration: none;
 }
 
@@ -635,7 +636,7 @@ input[type=radio][name=options] {
     background-color: #EEEEEE;
     padding: 8px 10px;
     font-weight: bold;
-    color: #777777;
+    color: #6B6B6B;
 }
 
 .order-nav a.nav-link {
@@ -655,6 +656,10 @@ small.rss {
     height: fit-content;
 }
 
+.badge-facet {
+    background-color: #EEEEEE;
+}
+
 .fw-normal {
     font-weight: normal;
 }
@@ -665,8 +670,8 @@ small.rss {
 
 .nav-pills .nav-link.active {
     background: none;
-    color: #3D8A8E;
-    border-bottom: 8px solid #3D8A8E;
+    color: #1E7D82;
+    border-bottom: 8px solid #1E7D82;
 }
 
 .nav-pills .nav-link:focus {
@@ -718,4 +723,35 @@ textarea.alert#id_description,  select.alert#id_type {
     margin-bottom: unset;
     border-radius: unset;
     padding: 2px;
+}
+
+.btn-primary {
+    --bs-btn-bg: #C7403B;
+    --bs-btn-border-color: #C7403B;
+    --bs-btn-active-bg: #8C0F0B;
+    --bs-btn-active-border-color: #8C0F0B;
+}
+
+.text-muted {
+    color: #424242 !important;
+}
+
+.text-success {
+    color: #007D23 !important;
+}
+
+.text-secondary {
+    color: #6C757D !important;
+}
+
+a, .btn-link, .page-link {
+    color: #B82A25;
+}
+
+.page-link.disabled {
+    color: #424242;
+}
+
+.btn-secondary {
+    background-color: #6C757D;
 }

--- a/lametro/templates/about/about.html
+++ b/lametro/templates/about/about.html
@@ -172,7 +172,7 @@
         <div class="col-md-8 pt-nav" id="procedures">
             <h3>Rules &amp; Procedures</h3>
             <p>Metro Board follows specific procedures to hold meetings and organize its members.</p>
-            <p><a href="http://boardarchives.metro.net/Items/2010/03_March/20100318EMACItem34.pdf" target="_blank"><i class='fa fa-fw fa-external-link'></i> Read about all Metro Rules &amp; Procedures.</a></p>
+            <p><a href="http://boardarchives.metro.net/Items/2010/03_March/20100318EMACItem34.pdf" target="_blank"><i class='fa fa-fw fa-external-link' aria-label="Opens in a new tab."></i> Read about all Metro Rules &amp; Procedures.</a></p>
         </div>
     </div>
 
@@ -184,7 +184,7 @@
                 Los Angeles, CA 90012-2952
             </address>
             <p>Metro Headquarters is located on the corner of Cesar E. Chavez Ave. and Vignes St.</p>
-            <p><a href="https://www.metro.net/about/contact/#visitus" target="_blank"><i class='fa fa-fw fa-external-link'></i> Get directions to Metro Headquarters.</a></p>
+            <p><a href="https://www.metro.net/about/contact/#visitus" target="_blank"><i class='fa fa-fw fa-external-link' aria-label="Opens in a new tab."></i> Get directions to Metro Headquarters.</a></p>
         </div>
     </div>
 

--- a/lametro/templates/about/about.html
+++ b/lametro/templates/about/about.html
@@ -214,7 +214,7 @@
 
             <p>The site was built by <a href='http://datamade.us' target="_blank">DataMade</a>, a civic technology company. They build open source technology using open data to empower journalists, researchers, governments and advocacy organizations.</p>
 
-            <p class="mt-4"><a href='http://datamade.us' target="_blank"><img style='height:50px;' src='{% static "images/datamade-logo.png" %}' /></a></p>
+            <p class="mt-4"><a href='http://datamade.us' target="_blank"><img style='height:50px;' src='{% static "images/datamade-logo.png" %}' alt="DataMade Home" /></a></p>
 
         </div>
 

--- a/lametro/templates/archive_search.html
+++ b/lametro/templates/archive_search.html
@@ -21,7 +21,7 @@
 
           <p>Search the LACMTA Board of Directors records from 1993 to 2015. Also includes Meeting Minutes for Metro predecessor public agencies: Los Angeles Metropolitan Transit Authority (LAMTA 1951-1964, incomplete), Southern California Rapid Transit District (SCRTD 1964-1993), Los Angeles County Transportation Commission (LACTC 1977-1993) and Rail Construction Corporation (RCC 1989-1993).</p>
 
-          <p>Subcategories to refine your search will appear just below the search box after a search is initiated.</p>
+          <p>Subcategories to refine your search will appear after a search is initiated.</p>
 
           <p>Looking for Board records from 2015 to present? <a href="{% url 'lametro:search' %}">Search current records &raquo;</a></p>
         </div>

--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -34,7 +34,7 @@
     <nav class="navbar fixed-top navbar-default navbar-expand-md navbar-light bg-light">
         <div class="container-fluid">
             <a class="navbar-brand me-auto" href="/">
-                <img id="logo" src="{% static IMAGES.logo %}"></img>
+                <img alt="" id="logo" src="{% static IMAGES.logo %}"></img>
                 <span id="logo-text">Metro Board</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">

--- a/lametro/templates/board_members/_council_info_blurb.html
+++ b/lametro/templates/board_members/_council_info_blurb.html
@@ -1,14 +1,14 @@
 <div class='card'>
   <div class="card-body">
     <h4 class="card-title">
-      <i class='fa fa-fw fa-info-circle'></i> What does Metro do?
+      <i class='fa fa-fw fa-info-circle' aria-hidden="true"></i> What does Metro do?
     </h4>
     <p class="card-text">
       {{CITY_COUNCIL_NAME}} sets policy, coordinates, plans, funds, builds, and operates transit services and transportation programs throughout Los Angeles County.
       It supports transportation improvement programs throughout Los Angeles County, and it also works in collaboration with other regional service providers.
     </p>
     <p>
-      <a href='/about/#about-city-council'>Read more <i class='fa fa-chevron-right'></i></a>
+      <a href='/about/#about-city-council'>Read more <i class='fa fa-chevron-right' aria-hidden="true"></i></a>
     </p>
   </div>
 </div>

--- a/lametro/templates/board_members/board_members.html
+++ b/lametro/templates/board_members/board_members.html
@@ -105,7 +105,7 @@
 <div class="container-fluid px-4 px-lg-5 mt-5 mt-lg-4">
     <div class="row">
         <div class="col-lg-8">
-            <h4><i class='fa fa-fw fa-list-ul'></i> Recent Activity</h4>
+            <h4><i class='fa fa-fw fa-list-ul' aria-hidden="true"></i> Recent Activity</h4>
             <table class="table" id="committee-actions">
                 <thead>
                     <tr>
@@ -143,7 +143,7 @@
             </table>
         </div>
         <div class="col-lg-4 mt-3 mt-lg-0">
-            <h4><i class='fa fa-fw fa-calendar-o'></i> Board of Directors Meetings</h4>
+            <h4><i class='fa fa-fw fa-calendar-o' aria-hidden="true"></i> Board of Directors Meetings</h4>
             {% for event in recent_events %}
                 <p class="event-listing">
                     {{event.start_time | date:'n/d/Y' }} - {{event.link_html | safe}}

--- a/lametro/templates/board_members/board_members.html
+++ b/lametro/templates/board_members/board_members.html
@@ -68,13 +68,19 @@
                     <label id="caltransToggle" class="btn btn-sm btn-caltrans">
                         <input type="radio" name="options" autocomplete="off"> Caltrans
                     </label>
-                    <a tabindex="0" class="map-info text-secondary" data-container="body" data-bs-toggle="popover" data-bs-html="true" data-bs-placement="right" title="What do these map layers represent?"
+                    <a href="#" tabindex="0" class="map-info text-secondary" data-container="body" data-bs-toggle="popover" data-bs-html="true" data-bs-placement="right" title="What do these map layers represent?"
                         data-bs-content="<p style='font-family: &quot;Open Sans&quot;, sans-serif; font-size: 14px;'>The three layers of this map show areas from which members of the Metro Board of Directors are nominated:</p>
                         <p><strong>(1) Los Angeles County Districts</strong> – The elected representative from each district from the Los Angeles County Board of Supervisors serves on the Metro Board.</p>
                         <p><strong>(2) Sectors</strong> – As defined by the California League of Cities, all the incorporated and unincorporated areas in Los Angeles County, excluding the City of Los Angeles, are divided into four sectors. Each sector nominates one representative, which is approved and appointed by all members of the California League of Cities, to serve on the Metro Board.</p>
                         <p><strong>(3) City of Los Angeles</strong> – Residents within the City of Los Angeles are represented by the mayor and three city appointees on the Metro Board.</p>
+                        <p><strong>(4) CalTrans District 7</strong> - The Governor of California appoints a non-voting member to the Metro Board. The California Department of Transportation (Caltrans) District 7 Director is the current appointee. CalTrans District 7 includes Los Angeles and Ventura counties.</p>
                         <p>Learn more about <a href='{% url 'about' %}#about-la-metro'>Metro Board appointments</a>.</p>
-                        <p>Click the Learn More tooltip again to dismiss.</p>">
+                        <p>Click the Learn More tooltip again to dismiss.</p>"
+                        aria-label="Learn more about this map. The three layers of this map show areas from which members of the Metro Board of Directors are nominated:
+                        1. Los Angeles County Districts – The elected representative from each district from the Los Angeles County Board of Supervisors serves on the Metro Board.
+                        2. Sectors – As defined by the California League of Cities, all the incorporated and unincorporated areas in Los Angeles County, excluding the City of Los Angeles, are divided into four sectors. Each sector nominates one representative, which is approved and appointed by all members of the California League of Cities, to serve on the Metro Board.
+                        3. City of Los Angeles – Residents within the City of Los Angeles are represented by the mayor and three city appointees on the Metro Board.
+                        4. CalTrans District 7 - The Governor of California appoints a non-voting member to the Metro Board. The California Department of Transportation (Caltrans) District 7 Director is the current appointee. CalTrans District 7 includes Los Angeles and Ventura counties.">
                         <p><i class="fa fa-info-circle text-secondary" aria-hidden="true"></i> Learn more</p>
                     </a>
                 </div>

--- a/lametro/templates/board_members/board_members.html
+++ b/lametro/templates/board_members/board_members.html
@@ -73,14 +73,14 @@
                         <p><strong>(1) Los Angeles County Districts</strong> – The elected representative from each district from the Los Angeles County Board of Supervisors serves on the Metro Board.</p>
                         <p><strong>(2) Sectors</strong> – As defined by the California League of Cities, all the incorporated and unincorporated areas in Los Angeles County, excluding the City of Los Angeles, are divided into four sectors. Each sector nominates one representative, which is approved and appointed by all members of the California League of Cities, to serve on the Metro Board.</p>
                         <p><strong>(3) City of Los Angeles</strong> – Residents within the City of Los Angeles are represented by the mayor and three city appointees on the Metro Board.</p>
-                        <p><strong>(4) CalTrans District 7</strong> - The Governor of California appoints a non-voting member to the Metro Board. The California Department of Transportation (Caltrans) District 7 Director is the current appointee. CalTrans District 7 includes Los Angeles and Ventura counties.</p>
+                        <p><strong>(4) Caltrans District 7</strong> - The Governor of California appoints a non-voting member to the Metro Board. The California Department of Transportation (Caltrans) District 7 Director is the current appointee. Caltrans District 7 includes Los Angeles and Ventura counties.</p>
                         <p>Learn more about <a href='{% url 'about' %}#about-la-metro'>Metro Board appointments</a>.</p>
                         <p>Click the Learn More tooltip again to dismiss.</p>"
                         aria-label="Learn more about this map. The three layers of this map show areas from which members of the Metro Board of Directors are nominated:
                         1. Los Angeles County Districts – The elected representative from each district from the Los Angeles County Board of Supervisors serves on the Metro Board.
                         2. Sectors – As defined by the California League of Cities, all the incorporated and unincorporated areas in Los Angeles County, excluding the City of Los Angeles, are divided into four sectors. Each sector nominates one representative, which is approved and appointed by all members of the California League of Cities, to serve on the Metro Board.
                         3. City of Los Angeles – Residents within the City of Los Angeles are represented by the mayor and three city appointees on the Metro Board.
-                        4. CalTrans District 7 - The Governor of California appoints a non-voting member to the Metro Board. The California Department of Transportation (Caltrans) District 7 Director is the current appointee. CalTrans District 7 includes Los Angeles and Ventura counties.">
+                        4. Caltrans District 7 - The Governor of California appoints a non-voting member to the Metro Board. The California Department of Transportation (Caltrans) District 7 Director is the current appointee. Caltrans District 7 includes Los Angeles and Ventura counties.">
                         <p><i class="fa fa-info-circle text-secondary" aria-hidden="true"></i> Learn more</p>
                     </a>
                 </div>
@@ -141,8 +141,8 @@
                     {% endfor %}
                     <tr>
                         <td class="text-end text-lg-center" colspan="3">
-                            <a href="" id="more-actions"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show more activity</a>
-                            <a href="" id="fewer-actions"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer activity</a>
+                            <a href="#" id="more-actions"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show more activity</a>
+                            <a href="#" id="fewer-actions"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer activity</a>
                         </td>
                     </tr>
                 </tbody>
@@ -156,8 +156,8 @@
                 </p>
             {% endfor %}
             <p>
-                <a href="" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show more meetings</a>
-                <a href="" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer meetings</a>
+                <a href="#" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show more meetings</a>
+                <a href="#" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer meetings</a>
             </p>
         </div>
     </div>

--- a/lametro/templates/board_members/board_members.html
+++ b/lametro/templates/board_members/board_members.html
@@ -146,7 +146,7 @@
             <h4><i class='fa fa-fw fa-calendar-o' aria-hidden="true"></i> Board of Directors Meetings</h4>
             {% for event in recent_events %}
                 <p class="event-listing">
-                    {{event.start_time | date:'n/d/Y' }} - {{event.link_html | safe}}
+                    <a href="{{event.event_page_url | safe}}" title="View Event Details">{{event.start_time | date:'n/d/Y' }} - {{event.name}}</a>
                 </p>
             {% endfor %}
             <p>

--- a/lametro/templates/board_members/board_members.html
+++ b/lametro/templates/board_members/board_members.html
@@ -135,8 +135,8 @@
                     {% endfor %}
                     <tr>
                         <td class="text-end text-lg-center" colspan="3">
-                            <a href="" id="more-actions"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show more</a>
-                            <a href="" id="fewer-actions"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer</a>
+                            <a href="" id="more-actions"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show more activity</a>
+                            <a href="" id="fewer-actions"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer activity</a>
                         </td>
                     </tr>
                 </tbody>
@@ -150,8 +150,8 @@
                 </p>
             {% endfor %}
             <p>
-                <a href="" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show more</a>
-                <a href="" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer</a>
+                <a href="" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show more meetings</a>
+                <a href="" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer meetings</a>
             </p>
         </div>
     </div>

--- a/lametro/templates/committee.html
+++ b/lametro/templates/committee.html
@@ -29,7 +29,7 @@
                     Committee {{ CITY_VOCAB.EVENTS }}
                 </h4>
                 <small class="rss">
-                    <a href="events/rss/" title="RSS feed for Committe Events by {{committee.name}}">
+                    <a href="events/rss/" title="RSS feed for Committe Events by {{committee.name}}" aria-label="RSS feed for Committe Events by {{committee.name}}">
                         <i class="fa fa-rss-square" aria-hidden="true"></i>
                     </a>
                 </small>

--- a/lametro/templates/committee.html
+++ b/lametro/templates/committee.html
@@ -45,8 +45,8 @@
                     {% endif %}
                 </p>
             {% endfor %}
-            <a href="" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show more</a>
-            <a href="" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer</a>
+            <a href="" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show more {{ CITY_VOCAB.EVENTS|lower }}</a>
+            <a href="" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer {{ CITY_VOCAB.EVENTS|lower }}</a>
         {% endif %}
     </div>
 </div>

--- a/lametro/templates/committee.html
+++ b/lametro/templates/committee.html
@@ -47,8 +47,8 @@
                     {% endif %}
                 </p>
             {% endfor %}
-            <a href="" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show more {{ CITY_VOCAB.EVENTS|lower }}</a>
-            <a href="" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer {{ CITY_VOCAB.EVENTS|lower }}</a>
+            <a href="#" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show more {{ CITY_VOCAB.EVENTS|lower }}</a>
+            <a href="#" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer {{ CITY_VOCAB.EVENTS|lower }}</a>
         {% endif %}
     </div>
 </div>

--- a/lametro/templates/committee.html
+++ b/lametro/templates/committee.html
@@ -38,10 +38,12 @@
             {% for event in committee.recent_events %}
                 <p class="event-listing my-2">
                     {% if event.status == 'cancelled' %}
-                        <del>{{ event.start_time | date:'n/d/Y' }} - {{ event.link_html | safe }}</del>
+                        <del>
+                            <a href="{{event.event_page_url | safe}}" title="View Event Details">{{event.start_time | date:'n/d/Y' }} - {{event.name}}</a>
+                        </del>
                         <span class="label label-stale">Cancelled</span>
                     {% else %}
-                        {{ event.start_time | date:'n/d/Y' }} - {{ event.link_html | safe}}
+                        <a href="{{event.event_page_url | safe}}" title="View Event Details">{{event.start_time | date:'n/d/Y' }} - {{event.name}}</a>
                     {% endif %}
                 </p>
             {% endfor %}

--- a/lametro/templates/event/_agenda_pdf_form.html
+++ b/lametro/templates/event/_agenda_pdf_form.html
@@ -7,7 +7,7 @@
     <!-- Upload a file and trigger the previewPDF function -->
     {{form.agenda}}
 
-    <p class="hidden my-3" id="pdf-form-message">You submitted the below agenda. Does it look correct?</p>
+    <p class="hidden my-3" id="pdf-form-message">You submitted the following agenda. Does it look correct?</p>
     <iframe
         id="pdf-check-viewer-test"
         class="pdf-viewer hidden"

--- a/lametro/templates/event/_agenda_url_form.html
+++ b/lametro/templates/event/_agenda_url_form.html
@@ -24,7 +24,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-              <p>You submitted the below agenda. Does it look correct?</p>
+              <p>You submitted the following agenda. Does it look correct?</p>
               <iframe
                   id="pdf-embed-agenda-check"
                   class="pdf-viewer"

--- a/lametro/templates/event/_event_header_live_public_comment.html
+++ b/lametro/templates/event/_event_header_live_public_comment.html
@@ -26,7 +26,7 @@
             {% if event.is_ongoing %}
                 <p>
                     <strong>You can submit your comments to the Metro Board of Directors during this meeting.</strong>
-                    Use the link below to comment on board reports on the agenda.
+                    Use the following link to comment on board reports on the agenda.
                 </p>
 
                 <p>

--- a/lametro/templates/event/_event_header_live_public_comment.html
+++ b/lametro/templates/event/_event_header_live_public_comment.html
@@ -31,7 +31,7 @@
 
                 <p>
                     <a class="btn btn-primary" href="{{ event.ecomment_url }}" target="_blank">
-                        <i class="fa fa-fw fa-external-link"></i>
+                        <i class="fa fa-fw fa-external-link" aria-label="Opens in a new tab."></i>
                         Go to public comment
                     </a>
                 </p>
@@ -46,7 +46,7 @@
                     <span class="d-block">Not seeing an agenda? Please use this link:</span>
                 {% endif %}
                 <a href="{{event.web_source.url}}" title="View on the {{CITY_VOCAB.SOURCE}} website" target="_blank">
-                    <i class="fa fa-fw fa-external-link" aria-hidden="true"></i>
+                    <i class="fa fa-fw fa-external-link" aria-label="Opens in a new tab."></i>
                     View on the {{CITY_VOCAB.SOURCE}} website
                 </a>
             </p>
@@ -88,7 +88,7 @@
                     <p>
                         <strong>On the web:</strong>
                         <a href="{{ event.ecomment_url }}" target="_blank">
-                            <i class="fa fa-fw fa-external-link" aria-hidden="true"></i>
+                            <i class="fa fa-fw fa-external-link" aria-label="Opens in a new tab."></i>
                             Go to public comment
                         </a>
                     </p>

--- a/lametro/templates/event/_event_header_no_live_public_comment.html
+++ b/lametro/templates/event/_event_header_no_live_public_comment.html
@@ -28,7 +28,7 @@
                     <span class="d-block">Not seeing an agenda? Please use this link:</span>
                 {% endif %}
                 <a href="{{event.web_source.url}}" title="View on the {{CITY_VOCAB.SOURCE}} website" target="_blank">
-                    <i class="fa fa-fw fa-external-link" aria-hidden="true"></i>
+                    <i class="fa fa-fw fa-external-link" aria-label="Opens in a new tab."></i>
                     View on the {{CITY_VOCAB.SOURCE}} website
                 </a>
             </p>

--- a/lametro/templates/event/event.html
+++ b/lametro/templates/event/event.html
@@ -52,7 +52,7 @@
         {% if user.is_authenticated %}
             {% if not event_ok %}
             <div class="card-body">
-                <p class="card-text">This event does not exist in Legistar. It may have been deleted from Legistar due to being a duplicate. To delete this event, click the button below.</p>
+                <p class="card-text">This event does not exist in Legistar. It may have been deleted from Legistar due to being a duplicate. To delete this event, click the following button.</p>
                 <a href="{% url 'delete_event' event.slug %}" class='btn btn-teal'>
                     <i class="fa fa-times" aria-hidden="true"></i>
                     Delete Event
@@ -133,7 +133,7 @@
                         </div>
 
                         <p class="d-none d-md-block">
-                            <em>To use a link in the PDF below, hold the CTRL button on your keyboard when clicking the link.</em>
+                            <em>To use a link in the following PDF, hold the CTRL button on your keyboard when clicking the link.</em>
                         </p>
                         <iframe
                             id="pdf-embed-agenda"

--- a/lametro/templates/events/events.html
+++ b/lametro/templates/events/events.html
@@ -83,8 +83,8 @@
                 {% endfor %}
                 </div>
 
-                <a href="" class="btn btn-primary" id="more-upcoming-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all upcoming meetings</a>
-                <a href="" class="btn btn-primary" id="fewer-upcoming-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer upcoming meetings</a>
+                <a href="#" class="btn btn-primary" id="more-upcoming-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all upcoming meetings</a>
+                <a href="#" class="btn btn-primary" id="fewer-upcoming-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer upcoming meetings</a>
 
                 <div class="row mt-5">
                     <div>
@@ -109,8 +109,8 @@
                 {% endfor %}
                 </div>
 
-                <a href="" class="btn btn-primary mb-5" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all past meetings</a>
-                <a href="" class="btn btn-primary mb-5" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer past meetings</a>
+                <a href="#" class="btn btn-primary mb-5" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all past meetings</a>
+                <a href="#" class="btn btn-primary mb-5" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer past meetings</a>
 
             {% elif past_events %}
                 <div class="row mt-4">
@@ -136,8 +136,8 @@
                 {% endfor %}
                 </div>
 
-                <a href="" class="btn btn-primary mb-5" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all past meetings</a>
-                <a href="" class="btn btn-primary mb-5" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer past meetings</a>
+                <a href="#" class="btn btn-primary mb-5" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all past meetings</a>
+                <a href="#" class="btn btn-primary mb-5" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer past meetings</a>
 
             {% elif select_events %}
                 <div class="row mt-4">

--- a/lametro/templates/events/events.html
+++ b/lametro/templates/events/events.html
@@ -75,13 +75,13 @@
                     <div class='col-md-8' id='events_message'></div>
                 </div>
 
-                <div class="row mt-4">
+                <ul class="row mt-4 search-results">
                 {% for date, event_list in future_events %}
-                    <div class="event-upcoming-listing mb-4">
+                    <li class="event-upcoming-listing mb-4">
                         {% include "events/_event_day.html" %}
-                    </div>
+                    </li>
                 {% endfor %}
-                </div>
+                </ul>
 
                 <a href="#" class="btn btn-primary" id="more-upcoming-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all upcoming meetings</a>
                 <a href="#" class="btn btn-primary" id="fewer-upcoming-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer upcoming meetings</a>
@@ -101,13 +101,13 @@
                     <div class='col-md-8' id='events_message'></div>
                 </div>
 
-                <div class="row mt-4">
+                <ul class="row mt-4 search-results">
                 {% for date, event_list in past_events %}
-                    <div class='event-listing mb-4'>
+                    <li class='event-listing mb-4'>
                         {% include "events/_past_event_day.html" %}
-                    </div>
+                    </li>
                 {% endfor %}
-                </div>
+                </ul>
 
                 <a href="#" class="btn btn-primary mb-5" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all past meetings</a>
                 <a href="#" class="btn btn-primary mb-5" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer past meetings</a>
@@ -128,13 +128,13 @@
                     <div class='col-md-8' id='events_message'></div>
                 </div>
 
-                <div class="row mt-4">
+                <ul class="row mt-4 search-results">
                 {% for date, event_list in past_events %}
-                    <div class='event-listing mb-4'>
+                    <li class='event-listing mb-4'>
                         {% include "events/_past_event_day.html" %}
-                    </div>
+                    </li>
                 {% endfor %}
-                </div>
+                </ul>
 
                 <a href="#" class="btn btn-primary mb-5" id="more-events"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all past meetings</a>
                 <a href="#" class="btn btn-primary mb-5" id="fewer-events"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer past meetings</a>
@@ -155,13 +155,13 @@
                     <div class='col-md-8' id='events_message'></div>
                 </div>
 
-                <div class="row mt-4">
+                <ul class="row mt-4 search-results">
                 {% for date, event_list in select_events %}
-                    <div class='mb-4'>
+                    <li class='mb-4'>
                         {% include "events/_past_event_day.html" %}
-                    </div>
+                    </li>
                 {% endfor %}
-                </div>
+                </ul>
 
             {% elif all_events %}
                 <div class="row mt-4">
@@ -179,13 +179,13 @@
                     <div class='col-md-8' id='events_message'></div>
                 </div>
 
-                <div class="row mt-4">
+                <ul class="row mt-4 search-results">
                 {% for date, event_list in all_events %}
-                    <div class='mb-4'>
+                    <li class='mb-4'>
                         {% include "events/_past_event_day.html" %}
-                    </div>
+                    </li>
                 {% endfor %}
-                </div>
+                </ul>
 
             {% else %}
                 <div class='row my-4'>

--- a/lametro/templates/events/events.html
+++ b/lametro/templates/events/events.html
@@ -57,7 +57,7 @@
                     <div>
                         <h2 class="d-inline">Upcoming {{ CITY_VOCAB.EVENTS }}</h2>
                         <small class="rss">
-                            <a href="rss/" title="RSS feed for Upcoming and Recent Events">
+                            <a href="rss/" title="RSS feed for Upcoming and Recent Events" aria-label="RSS feed for Upcoming and Recent Events">
                                 <i class="fa fa-rss-square" aria-hidden="true"></i>
                             </a>
                         </small>
@@ -90,7 +90,7 @@
                     <div>
                         <h2 class="d-inline">Past {{ CITY_VOCAB.EVENTS }}</h2>
                         <small class="rss">
-                            <a href="rss/" title="RSS feed for Upcoming and Recent Events">
+                            <a href="rss/" title="RSS feed for Upcoming and Recent Events" aria-label="RSS feed for Upcoming and Recent Events">
                                 <i class="fa fa-rss-square" aria-hidden="true"></i>
                             </a>
                         </small>
@@ -117,7 +117,7 @@
                     <div>
                         <h2 class="d-inline">Past {{ CITY_VOCAB.EVENTS }}</h2>
                         <small class="rss">
-                            <a href="rss/" title="RSS feed for Upcoming and Recent Events">
+                            <a href="rss/" title="RSS feed for Upcoming and Recent Events" aria-label="RSS feed for Upcoming and Recent Events">
                                 <i class="fa fa-rss-square" aria-hidden="true"></i>
                             </a>
                         </small>
@@ -144,7 +144,7 @@
                     <div>
                         <h2 class="d-inline">{{ CITY_VOCAB.EVENTS }} from {{ start_date }} to {{ end_date }}</h2>
                         <small class="rss">
-                            <a href="rss/" title="RSS feed for Upcoming and Recent Events">
+                            <a href="rss/" title="RSS feed for Upcoming and Recent Events" aria-label="RSS feed for Upcoming and Recent Events">
                                 <i class="fa fa-rss-square" aria-hidden="true"></i>
                             </a>
                         </small>
@@ -168,7 +168,7 @@
                     <div>
                         <h2 class="d-inline">All {{ CITY_VOCAB.EVENTS }}</h2>
                         <small class="rss">
-                            <a href="rss/" title="RSS feed for Upcoming and Recent Events">
+                            <a href="rss/" title="RSS feed for Upcoming and Recent Events" aria-label="RSS feed for Upcoming and Recent Events">
                                 <i class="fa fa-rss-square" aria-hidden="true"></i>
                             </a>
                         </small>

--- a/lametro/templates/index/_meeting_details_current.html
+++ b/lametro/templates/index/_meeting_details_current.html
@@ -31,7 +31,7 @@
                         {% if meeting.is_ongoing and USING_ECOMMENT %}
                             <p>
                                 <a class="btn btn-primary" href="{{ event.ecomment_url }}" target="_blank">
-                                    <i class='fa fa-fw fa-external-link'></i>
+                                    <i class='fa fa-fw fa-external-link' aria-label='Opens in a new tab.'></i>
                                     Go to public comment
                                 </a>
                             </p>
@@ -98,14 +98,14 @@
 
                 {% if USING_ECOMMENT %}
                     <a class="btn btn-sm btn-primary current-meeting-info" href="{{ current_meeting.first.ecomment_url }}" target="_blank">
-                        <i class='fa fa-fw fa-external-link'></i>
+                        <i class='fa fa-fw fa-external-link' aria-label='Opens in a new tab.'></i>
                         Go to public comment
                     </a>
                 {% endif %}
 
                 {% if current_meeting.first.documents.all %}
                     <a class="btn btn-sm btn-teal current-meeting-info" id="pdf-download-link" target='_blank' href='{{ current_meeting.first.documents.all|find_agenda_url }}'>
-                        <i class='fa fa-fw fa-download'></i>
+                        <i class='fa fa-fw fa-download' aria-hidden="true"></i>
                         Get Agenda PDF
                     </a>
                 {% endif %}

--- a/lametro/templates/index/_meeting_details_next.html
+++ b/lametro/templates/index/_meeting_details_next.html
@@ -37,7 +37,7 @@
         {% if meeting.documents.all %}
           <div class="row">
             <div class="col-7">
-              <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='#'><i class='fa fa-fw fa-download'></i> Get Agenda PDF</a>
+              <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='#'><i class='fa fa-fw fa-download' aria-hidden="true"></i> Get Agenda PDF</a>
             </div>
           </div>
         {% endif %}

--- a/lametro/templates/index/index.html
+++ b/lametro/templates/index/index.html
@@ -20,7 +20,7 @@
                 <p>
                   <span class="text-light">
                     Begin typing in the search bar to add a keyword or pick a suggested topic as they appear. Press enter to perform a search for your selected terms.
-                    <i id="beta-info" class="fa fa-info-circle fa-fw" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom" title="<strong>Suggested topics are a new feature.</strong> If you aren't seeing helpful suggestions or have any additional feedback or questions, get in touch with us at <a href='mailto:boardreport@metro.net'>boardreport@metro.net</a>."></i>
+                    <i id="beta-info" class="fa fa-info-circle fa-fw" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom" title="<strong>Suggested topics are a new feature.</strong> If you aren't seeing helpful suggestions or have any additional feedback or questions, get in touch with us at <a href='mailto:boardreport@metro.net'>boardreport@metro.net</a>." aria-label="Suggested topics are a new feature. If you aren't seeing helpful suggestions or have any additional feedback or questions, get in touch with us at boardreport@metro.net."></i>
                   </span>
                 </p>
                 <div class="site-intro-search">

--- a/lametro/templates/legislation.html
+++ b/lametro/templates/legislation.html
@@ -29,12 +29,12 @@
 
             <p>
                 <a href="{{ legislation.bill_type | get_bill_type_link }}" title="Learn more about this type of Board Report" target="_blank">
-                    <i class="fa fa-fw fa-external-link"></i> Learn more about this type of Board Report
+                    <i class="fa fa-fw fa-external-link" aria-label="Opens in a new tab."></i> Learn more about this type of Board Report
                 </a>
             </p>
             <p>
                 <a href="{{legislation.web_source.url}}" title="View on the {{CITY_VOCAB.SOURCE}} website" target="_blank">
-                    <i class="fa fa-fw fa-external-link"></i> View on the {{CITY_VOCAB.SOURCE}} website
+                    <i class="fa fa-fw fa-external-link" aria-label="Opens in a new tab."></i> View on the {{CITY_VOCAB.SOURCE}} website
                 </a>
             </p>
         </div>
@@ -297,7 +297,7 @@
         }
         else{
             $('#pdf-embed').hide()
-            $('#pdf-download-link').html("<i class='fa fa-fw fa-external-link'></i> View PDF")
+            $('#pdf-download-link').html("<i class='fa fa-fw fa-external-link' aria-label='Opens in a new tab.'></i> View PDF")
         }
 
         {% for source in legislation.sources.all %}

--- a/lametro/templates/minutes/minutes.html
+++ b/lametro/templates/minutes/minutes.html
@@ -45,8 +45,8 @@
             {% endfor %}
           </div>
         {% endfor %}
-        <a href="" class="btn btn-primary" id="more-minutes"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all minutes</a>
-        <a href="" class="btn btn-primary" id="fewer-minutes"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer minutes</a>
+        <a href="#" class="btn btn-primary" id="more-minutes"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all minutes</a>
+        <a href="#" class="btn btn-primary" id="fewer-minutes"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer minutes</a>
       {% else %}
         <div class="row my-4">
           <h5>No minutes have been found.</h5>

--- a/lametro/templates/minutes/minutes.html
+++ b/lametro/templates/minutes/minutes.html
@@ -31,11 +31,12 @@
 
 <div class="row">
   <div class="col-md-9">
+    <h2 class="mb-3">Minutes</h2>
     <div id="minutes-list">
-      <h2 class="mb-3">Minutes</h2>
       {% if all_minutes %}
+        <ul class="search-results">
         {% for date, minutes_list in all_minutes %}
-          <div class="minutes-listing mb-5">
+          <li class="minutes-listing mb-5">
             <h5 class="text-default mb-0">
               <i class="fa fa-fw fa-calendar-o" aria-hidden="true"></i> {{ date | date:"D m/d/Y"}}
             </h5>
@@ -43,8 +44,9 @@
             {% for e in minutes_list %}
               {% include 'minutes/_minutes_item.html' %}
             {% endfor %}
-          </div>
+          </li>
         {% endfor %}
+        </ul>
         <a href="#" class="btn btn-primary" id="more-minutes"><i class="fa fa-fw fa-chevron-down" aria-hidden="true"></i> Show all minutes</a>
         <a href="#" class="btn btn-primary" id="fewer-minutes"><i class="fa fa-fw fa-chevron-up" aria-hidden="true"></i> Show fewer minutes</a>
       {% else %}

--- a/lametro/templates/person/person.html
+++ b/lametro/templates/person/person.html
@@ -23,7 +23,7 @@
                         Former {{ person.latest_council_membership.role }}
                     {% endif %}
                 </div>
-                <a href="rss/" title="RSS feed for Sponsored Board Actions by {{person.name}}"><i class="fa fa-rss-square" aria-hidden="true"></i></a>
+                <a href="rss/" title="RSS feed for Sponsored Board Actions by {{person.name}}" aria-label="RSS feed for Sponsored Board Actions by {{person.name}}"><i class="fa fa-rss-square" aria-hidden="true"></i></a>
             </div>
         </div>
     </div>

--- a/lametro/templates/person/person.html
+++ b/lametro/templates/person/person.html
@@ -73,9 +73,9 @@
 
             {% if map_geojson %}
                 {% if person.current_district %}
-                    <h4>{{ person.current_district | format_district }} map</h4>
+                    <h4 id="map-label">{{ person.current_district | format_district }} map</h4>
                 {% endif %}
-                <div id='map-detail'></div>
+                <div id='map-detail' aria-labelledby="map-label"></div>
             {% endif %}
 
         </div>

--- a/lametro/templates/search/_search_header.html
+++ b/lametro/templates/search/_search_header.html
@@ -3,7 +3,7 @@
 </p>
 <p id="search-help">
     Begin typing in the search bar to add a keyword or pick a suggested topic as they appear. Press enter to perform a search for your selected terms.
-    <a id="beta-info" class="hover-hand" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right" title="<strong>Suggested topics are a new feature.</strong> If you aren't seeing helpful suggestions or have any additional feedback or questions, get in touch with us at <a href='mailto:boardreport@metro.net'>boardreport@metro.net</a>." aria-label="Suggested topics are a new feature. If you aren't seeing helpful suggestions or have any additional feedback or questions, get in touch with us at boardreport@metro.net.">
+    <a href="#" id="beta-info" class="hover-hand" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right" title="<strong>Suggested topics are a new feature.</strong> If you aren't seeing helpful suggestions or have any additional feedback or questions, get in touch with us at <a href='mailto:boardreport@metro.net'>boardreport@metro.net</a>." aria-label="Suggested topics are a new feature. If you aren't seeing helpful suggestions or have any additional feedback or questions, get in touch with us at boardreport@metro.net.">
         <i id="beta-info" class="fa fa-info-circle fa-fw" aria-hidden="true"></i>
     </a>
 </p>

--- a/lametro/templates/search/_search_header.html
+++ b/lametro/templates/search/_search_header.html
@@ -3,7 +3,7 @@
 </p>
 <p id="search-help">
     Begin typing in the search bar to add a keyword or pick a suggested topic as they appear. Press enter to perform a search for your selected terms.
-    <a id="beta-info" class="hover-hand" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right" title="<strong>Suggested topics are a new feature.</strong> If you aren't seeing helpful suggestions or have any additional feedback or questions, get in touch with us at <a href='mailto:boardreport@metro.net'>boardreport@metro.net</a>.">
-        <i id="beta-info" class="fa fa-info-circle fa-fw"></i>
+    <a id="beta-info" class="hover-hand" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right" title="<strong>Suggested topics are a new feature.</strong> If you aren't seeing helpful suggestions or have any additional feedback or questions, get in touch with us at <a href='mailto:boardreport@metro.net'>boardreport@metro.net</a>." aria-label="Suggested topics are a new feature. If you aren't seeing helpful suggestions or have any additional feedback or questions, get in touch with us at boardreport@metro.net.">
+        <i id="beta-info" class="fa fa-info-circle fa-fw" aria-hidden="true"></i>
     </a>
 </p>

--- a/lametro/templates/search/_search_result.html
+++ b/lametro/templates/search/_search_result.html
@@ -29,7 +29,7 @@
 
     <div class="col-2 col-sm-1">
         <a class='btn-bill-detail' target='_blank' href='/board-report/{{ r.slug }}/' aria-label="View this Board Report's details in a new tab">
-            <i class="fa fa-fw fa-chevron-right"></i>
+            <i class="fa fa-fw fa-chevron-right" aria-hidden="true"></i>
         </a>
     </div>
 </div>

--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -216,20 +216,22 @@
                 </div>
             </div>
         {% endif %}
+        <ul class="search-results">
+            {% for result in page.object_list %}
+                <li>
+                    <!-- Legislation result -->
 
-        {% for result in page.object_list %}
+                    {% with r=result %}
+                        {% include 'search/_search_result.html' %}
+                    {% endwith %}
 
-            <!-- Legislation result -->
+                    {% include 'search/_tags.html' %}
 
-            {% with r=result %}
-                {% include 'search/_search_result.html' %}
-            {% endwith %}
-
-            {% include 'search/_tags.html' %}
-
-            {% empty %}
-            {% include 'search/_empty_search_message.html' %}
-        {% endfor %}
+                    {% empty %}
+                    {% include 'search/_empty_search_message.html' %}
+                </li>
+            {% endfor %}
+        </ul>
     </div>
 </div>
 

--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -34,7 +34,7 @@
         {% if selected_facets %}
             <p class="mb-0">
                 <a href="/search/" class="btn btn-sm btn-secondary mb-2">
-                <i class='fa fa-times'></i>
+                <i class='fa fa-times' aria-hidden="true"></i>
                 Clear all filters
                 </a>
             </p>
@@ -199,11 +199,11 @@
 
                 <small class="rss">
                     {% if query and selected_facets %}
-                        <a href="/search/rss/?q={{request.GET.q}}{% for key, values in selected_facets.items %}{% for value in values %}&selected_facets={{key}}:{{value}}{% endfor %}{% endfor %}" title="RSS feed">
+                        <a href="/search/rss/?q={{request.GET.q}}{% for key, values in selected_facets.items %}{% for value in values %}&selected_facets={{key}}:{{value}}{% endfor %}{% endfor %}" title="RSS feed" aria-label="RSS feed">
                     {% elif selected_facets %}
-                        <a href="/search/rss/?{% for key, values in selected_facets.items %}{% for value in values %}&selected_facets={{key}}:{{value}}{% endfor %}{% endfor %}" title="RSS feed">
+                        <a href="/search/rss/?{% for key, values in selected_facets.items %}{% for value in values %}&selected_facets={{key}}:{{value}}{% endfor %}{% endfor %}" title="RSS feed" aria-label="RSS feed">
                     {% else %}
-                        <a href="/search/rss/?q={{request.GET.q}}" title="RSS feed">
+                        <a href="/search/rss/?q={{request.GET.q}}" title="RSS feed" aria-label="RSS feed">
                     {% endif %}
 
                     <i class="fa fa-rss-square" aria-hidden="true"></i></a>

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -575,7 +575,7 @@ def test_delete_button_shows(
     delete_button_text = (
         "This event does not exist in Legistar. It may have "
         "been deleted from Legistar due to being a duplicate. "
-        "To delete this event, click the button below."
+        "To delete this event, click the following button."
     )
 
     with requests_mock.Mocker() as m:


### PR DESCRIPTION
## Overview

This branch aims to improve on the "perceivable" category of WCAG standards for the app. Each of the areas of improvement are listed in the connected issue. Most notable changes are higher color contrast throughout the site, and the addition of underlines to links.

- Connects #1021

### Demo

![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/9ec3c1fc-abe1-4d75-88e4-e6fdd5a5c974)

### Notes
The original issues for each category are listed in #1021
- 1.1.1 Non-text Content:
  - I decided on adding an `aria-labelledby` as the alternative to the maps on board member detail pages. Screen readers will read the corresponding heading when focusing on those maps.
  - As far as the board member listing page maps, there's a couple alternatives to that map on that same page, so I've left that mostly untouched. There's both the Learn More tooltip above the map, as well as the table next to it that lists out all the people that would've been described by the map.
- 1.4.1 Use of Color:
  - I figured that since [github changed their default to having all links be underlined for accessibility's sake](https://github.blog/changelog/2023-10-18-new-default-underlined-links-for-improved-accessibility/#:~:text=By%20default%2C%20links%20within%20text,managing%20the%20appearance%20of%20links), then maybe metro can too. If the underlines are a bit much then we can try changing the lightness of the links instead
  - There are some links that probably don't need to be underlined since they don't navigate to another page, but instead manipulate something on the same page. This includes things like the show more links on the board members page. To fix this, in another category I'll be changing `<a>` tags that don't send you to a different page to `<button>` tags instead [as suggested in this article](https://www.a11y-101.com/design/button-vs-link).
![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/fe755186-5b3d-46b2-b84f-e776e6a155fb)
- 1.4.13 Content on Hover or Focus:
  - Content inside the tooltips wasn't tabbable and the learn more icon's popup appeared at the end of the DOM, preventing screen readers from accessing it at an appropriate time. To fix both of those issues, I've added an aria descriptor to both those elements.

## Testing Instructions

 * Navigate the site (optionally with a screen reader)
 * Asses if the points covered in the issue have been properly addressed
 * Asses the changes made to colors and language  
