### PR TITLE
Remove recap link from event detail and listing pages

### DIFF
--- a/lametro/templates/event/event.html
+++ b/lametro/templates/event/event.html
@@ -107,12 +107,6 @@
                             <p>
                                 <a href="{{ minutes.links.get.url }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
                             </p>
-                            {% elif 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
-                            <h4>Minutes</h4>
-                            <p>
-                                <a href="http://boardarchives.metro.net/recaps/" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> View Recap</a>
-                                </br>
-                            </p>
                             {% endif %}
                         {% endif %}
 

--- a/lametro/templates/events/_past_event_day.html
+++ b/lametro/templates/events/_past_event_day.html
@@ -60,11 +60,6 @@
             <p>
                 <a href="{{ minutes }}">Minutes</a>
             </p>
-            {% elif 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
-            <p>
-                <a href="http://boardarchives.metro.net/recaps/" target="_blank">Recap</a>
-                </br>
-            </p>
             {% endif %}
         {% endwith %}
     </div>


### PR DESCRIPTION
## Overview

This removes recap links from events since that page isn't being updated anymore

- Closes #1041

## Testing Instructions

 * Head to the events listing page
 * Confirm that none of the past events have a recap link
   * At the time of writing, the Regular Board meeting on Thu 11/30/2023 has a Recap link on the live site. So this should no longer be showing.
 * Head to an event detail page (preferably one that has a recap on the live site)
 * Confirm that the recap link no longer appears on that page either
