### PR TITLE
Remove encrypted configs from blackbox files

### DIFF
--- a/keyrings/live/blackbox-files.txt
+++ b/keyrings/live/blackbox-files.txt
@@ -1,3 +1,1 @@
 configs/lametro_service_acct_key.json
-configs/settings_deployment.production.py
-configs/settings_deployment.staging.py


### PR DESCRIPTION
## Overview

See title. Now that we've moved to Heroku, we no longer use encrypted settings files.

Connects #1043