### PR TITLE
Fix slash escaping in searches

### DIFF
--- a/lametro/forms.py
+++ b/lametro/forms.py
@@ -34,8 +34,8 @@ class LAMetroCouncilmaticSearchForm(CouncilmaticSearchForm):
             q += '"'
 
         # Escape reserved characters
-        reserved_characters = "|&*/\!{[]}~-+'()^:"
-        mapping = {char: f"\{char}" for char in reserved_characters}
+        reserved_characters = "|&*/\!{[]}~-+'()^:"  # noqa
+        mapping = {char: f"\{char}" for char in reserved_characters}  # noqa
         table = str.maketrans(mapping)
         q = q.translate(table)
 

--- a/lametro/forms.py
+++ b/lametro/forms.py
@@ -34,10 +34,10 @@ class LAMetroCouncilmaticSearchForm(CouncilmaticSearchForm):
             q += '"'
 
         # Escape reserved characters
-        reserved_characters = r"""|&*\/!{[]}~-+'()^:"""
-
-        for char in reserved_characters:
-            q = q.replace(char, r"\{}".format(char))
+        reserved_characters = "|&*/\!{[]}~-+'()^:"
+        mapping = {char: f"\{char}" for char in reserved_characters}
+        table = str.maketrans(mapping)
+        q = q.translate(table)
 
         # Downcase boolean operators
         for op in ("OR", "AND"):

--- a/lametro/forms.py
+++ b/lametro/forms.py
@@ -34,7 +34,7 @@ class LAMetroCouncilmaticSearchForm(CouncilmaticSearchForm):
             q += '"'
 
         # Escape reserved characters
-        reserved_characters = r"""|&*/\!{[]}~-+'()^:"""
+        reserved_characters = r"""|&*\/!{[]}~-+'()^:"""
 
         for char in reserved_characters:
             q = q.replace(char, r"\{}".format(char))


### PR DESCRIPTION
## Overview

A number of the search errors we've had are due to slashes in queries (e.g. `Westside Subway Extension/Purple Line Extension Phase 2`). It seems like we were double escaping `\` which caused an error in Elastic.

Connects #1049 

## Testing Instructions

 * Execute a search that includes a `/`
 * Verify that you don't get an error
