### PR TITLE
Add sentry performance tracking

### DIFF
--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -215,6 +215,9 @@ if SENTRY_DSN:
         # If you wish to associate users to errors (assuming you are using
         # django.contrib.auth) you may enable sending PII data.
         send_default_pii=True,
+        release=f"{os.environ['HEROKU_RELEASE_VERSION']}-{os.environ['HEROKU_APP_NAME']}",
+        enable_tracing=True,
+        traces_sample_rate=0.05,
     )
 
 # Use standard logging module to catch errors in import_data (which uses a 'logger')


### PR DESCRIPTION
## Overview

See title. This will allow us to have more fine-grained analytics on app performance in Sentry.

Connects #1062 

## Notes

I've enabled the [Heroku Dyno Metadata add on](https://devcenter.heroku.com/articles/dyno-metadata) for both staging and production so we have access to `HEROKU_RELEASE_VERSION` and `HEROKU_APP_NAME` environment variables.