### PR TITLE
Update sentry package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Django>=3.2,<3.3
 psycopg2-binary>=2.8
 opencivicdata>=3.1.0
 django-debug-toolbar>=3.4,<3.5
-sentry-sdk==0.14.2
+sentry-sdk[django]==1.39.2
 gunicorn==19.6.0
 dj_database_url
 django-recaptcha==2.0.6


### PR DESCRIPTION
## Overview

Looks like our sentry version was quite old (0.42 vs 1.39) and didn't support the `enable_tracing` flag.

Connects #1062 