### PR TITLE
Provide Sentry with release info + re-format files

### DIFF
--- a/.github/workflows/associate_commits.yml
+++ b/.github/workflows/associate_commits.yml
@@ -1,0 +1,31 @@
+name: Associate commits to heroku release in sentry
+
+on: deployment_status
+
+jobs:
+  associate:
+    if: github.event.deployment_status.state == 'success' && github.event.deployment.environment == 'la-metro-councilmatic-prod'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: '${{ github.event.deployment_status.deployment.ref }}'
+          fetch-depth: 0
+      - name: install sentry-cli
+        run: pip install sentry-cli
+      - name: Sleep to make sure that heroku deployment is really done
+        run: sleep 300
+        shell: bash
+      - name: get release version
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: echo "HEROKU_RELEASE=`heroku config:get HEROKU_RELEASE_VERSION -a la-metro-councilmatic-prod`-la-metro-councilmatic-prod" >> "$GITHUB_ENV"
+      - name: inform sentry about release
+        env:
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          sentry-cli releases new -p chicago-councilmatic $HEROKU_RELEASE
+          sentry-cli releases set-commits $HEROKU_RELEASE
+          sentry-cli releases finalize $HEROKU_RELEASE

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.1.1
     hooks:
       - id: black
 

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -47,7 +47,6 @@ logger = logging.getLogger(__name__)
 class SourcesMixin(object):
     @property
     def web_source(self):
-
         return self.sources.get(note="web")
 
     @property

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 class SourcesMixin(object):
     @property
     def web_source(self):
+
         return self.sources.get(note="web")
 
     @property
@@ -274,9 +275,11 @@ class LAMetroBill(Bill, SourcesMixin):
             data,
             key=lambda x: (
                 x["date"],
-                x["description"].upper()
-                if x["description"] == "SCHEDULED"
-                else x["description"].lower(),
+                (
+                    x["description"].upper()
+                    if x["description"] == "SCHEDULED"
+                    else x["description"].lower()
+                ),
             ),
         )
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -90,9 +90,9 @@ class LAMetroIndexView(IndexView, FormView):
         extra["upcoming_board_meetings"] = self.event_model.upcoming_board_meetings()[
             :2
         ]
-        extra[
-            "most_recent_past_meetings"
-        ] = self.event_model.most_recent_past_meetings()
+        extra["most_recent_past_meetings"] = (
+            self.event_model.most_recent_past_meetings()
+        )
         extra["current_meeting"] = self.event_model.current_meeting()
         extra["bilingual"] = bool([e for e in extra["current_meeting"] if e.bilingual])
         extra["USING_ECOMMENT"] = settings.USING_ECOMMENT

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -20,7 +20,6 @@ from lametro.forms import AgendaPdfForm
 
 
 def mock_streaming_meetings(mocker, return_value=None):
-
     mock_response = mocker.MagicMock(spec=requests.Response)
     mock_response.json.return_value = return_value if return_value else []
     mock_response.status_code = 200

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -20,6 +20,7 @@ from lametro.forms import AgendaPdfForm
 
 
 def mock_streaming_meetings(mocker, return_value=None):
+
     mock_response = mocker.MagicMock(spec=requests.Response)
     mock_response.json.return_value = return_value if return_value else []
     mock_response.status_code = 200
@@ -320,8 +321,7 @@ def test_streamed_meeting_is_marked_as_broadcast(concurrent_current_meetings, mo
         assert not any([test_event_b.is_ongoing, test_event_b.has_passed])
 
 
-def test_check_current_meeting():
-    ...
+def test_check_current_meeting(): ...
 
 
 def get_event_id():


### PR DESCRIPTION
## Overview

This PR adds in a Github action to let Sentry know about release info per [this comment](https://github.com/Metro-Records/la-metro-councilmatic/pull/1068#pullrequestreview-1842065133).

Also, black has been updated so some of the Python files need to be re-formatted to pass our actions code test.

Connects #1062 

## Testing Instructions

 * Verify that tests pass