### PR TITLE
Update gunicorn + set max requests

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -14,4 +14,4 @@ release:
   image: web
 # The command that runs your application. Replace 'app' with the name of your app.
 run:
-  web: gunicorn -t 180 --log-level debug councilmatic.wsgi:application
+  web: gunicorn --max-requests 1000 --max-requests-jitter 50 -t 180 --log-level debug councilmatic.wsgi:application

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ psycopg2-binary>=2.8
 opencivicdata>=3.1.0
 django-debug-toolbar>=3.4,<3.5
 sentry-sdk[django]==1.39.2
-gunicorn==21.0.1
+gunicorn==21.2.0
 dj_database_url
 django-recaptcha==2.0.6
 google-api-python-client==2.42.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ psycopg2-binary>=2.8
 opencivicdata>=3.1.0
 django-debug-toolbar>=3.4,<3.5
 sentry-sdk[django]==1.39.2
-gunicorn==19.6.0
+gunicorn==21.0.1
 dj_database_url
 django-recaptcha==2.0.6
 google-api-python-client==2.42.0


### PR DESCRIPTION
## Overview

This PR updates gunicorn and sets the `max_requests` and `max_requests_jitter` gunicorn options.

## Notes

### max_requests

We've been experiencing what seems to be a memory leak on Heroku. [This post](https://adamj.eu/tech/2019/09/19/working-around-memory-leaks-in-your-django-app/) outlines how setting `max_requests` can address memory issues. It's also recommended in the [gunicorn docs](https://docs.gunicorn.org/en/stable/settings.html?highlight=max_requests#max-requests).

### Updating gunicorn

We're currently running version 19.6.0 which was released in 2016! Memory leaks are notoriously painful to debug because they don't necessarily even come from application code-- they can come from app dependencies. This old version of gunicorn could be causing issues with our newer version of Python itself, Django, or another Python package. 

Connects #1062