### PR TITLE
Don't highlight tiny words in search results

### DIFF
--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -10,10 +10,9 @@ from django.utils import timezone
 from councilmatic.settings_jurisdiction import legislation_types
 from councilmatic.settings import PIC_BASE_URL
 from councilmatic_core.models import Person, Bill
-from councilmatic_core.utils import ExactHighlighter
 
 from lametro.models import app_timezone, Alert
-from lametro.utils import format_full_text, parse_subject
+from lametro.utils import ExactHighlighter, format_full_text, parse_subject
 
 
 register = template.Library()

--- a/lametro/utils.py
+++ b/lametro/utils.py
@@ -5,7 +5,39 @@ import pytz
 
 from django.conf import settings
 
+from haystack.utils.highlighting import Highlighter
+
 app_timezone = pytz.timezone(settings.TIME_ZONE)
+
+
+class ExactHighlighter(Highlighter):
+    """
+    This class customizes the Haystack Highlighter to allow for
+    highlighting multi-word strings.
+    https://django-haystack.readthedocs.io/en/master/highlighting.html#highlighter
+    https://github.com/django-haystack/django-haystack/blob/master/haystack/utils/highlighting.py
+
+    Use this class to build custom filters in `search_result.html`.
+    """
+
+    def __init__(self, query, **kwargs):
+        super(Highlighter, self).__init__()
+        self.query_words = self.make_query_words(query)
+
+    def make_query_words(self, query):
+        query_words = set()
+        if query.startswith('"') and query.endswith('"'):
+            query_words.add(query.strip('"'))
+        else:
+            query_words = set(
+                [
+                    word.lower()
+                    for word in query.split()
+                    if not word.startswith("-") and len(word) > 3
+                ]
+            )
+
+        return query_words
 
 
 def format_full_text(full_text):


### PR DESCRIPTION
## Overview

Previously we were using a more naive [highlighting scheme](https://github.com/datamade/django-councilmatic/blob/b550d380365a1e525f2f721cae5a480a4ef59da5/councilmatic_core/utils.py#L8) that would catch small words like "a" or "the". It's likely that this has been causing memory errors as we've set up Haystack to highlight all board report attachment text.

This PR attempts to make search result highlighting more efficient by only considering words with of >3 length. 

Connects #718