### PR TITLE
Add haystack to minimal settings

### DIFF
--- a/councilmatic/minimal_settings.py
+++ b/councilmatic/minimal_settings.py
@@ -19,3 +19,13 @@ INSTALLED_APPS = (
     "debug_toolbar",
     "captcha",
 )
+
+HAYSTACK_CONNECTIONS = {
+    "default": {
+        "ENGINE": "haystack.backends.elasticsearch7_backend.Elasticsearch7SearchEngine",
+        "URL": "http://elasticsearch:9200",
+        "INDEX_NAME": "lametro",
+        "SILENTLY_FAIL": False,
+        "BATCH_SIZE": 10,
+    }
+}


### PR DESCRIPTION
## Overview

It looks like the `collectstatic` commands fails without it now due to #1074.

<img width="1021" alt="Screenshot 2024-02-08 at 12 35 42 PM" src="https://github.com/Metro-Records/la-metro-councilmatic/assets/36973363/2dd65b4d-b522-4a67-aa3f-7ec5ec35e3c6">

Connects #718 