### PR TITLE
Add legistar link to 404 page

### DIFF
--- a/lametro/templates/404.html
+++ b/lametro/templates/404.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}Page Not Found{% endblock %}
+
+{% block full_content %}
+
+    <div class="row-fluid">
+        <div class="col-sm-12">
+            <h1>Page Not Found</h1>
+            <p>Please visit <a href="https://metro.legistar.com/calendar.aspx" target="_blank">https://metro.legistar.com/calendar.aspx</a> to access Metro Board Meetings &amp; Agendas.</p>
+            <p><a href="/">&laquo; go back to the home page</a></p>
+        </div>
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
## Overview

Connects #1063 

### Demo

<img width="951" alt="Screenshot 2024-02-27 at 2 55 40 PM" src="https://github.com/Metro-Records/la-metro-councilmatic/assets/36973363/a45ccc67-4350-41cb-a4f2-f1d8ddb13449">

## Testing Instructions

 * Set `DEBUG=False` in `.env.local`
 * Verify that you get the updated 404 page when you go to a page that doesn't exist (e.g. `localhost:8001/nonexistentpage.html`)