### PR TITLE
Hide Measure M committees on committee listing page

### DIFF
--- a/lametro/views.py
+++ b/lametro/views.py
@@ -533,6 +533,7 @@ class LACommitteesView(CommitteesView):
             LAMetroOrganization.objects.filter(classification="committee")
             .filter(memberships__in=memberships)
             .distinct()
+            .exclude(name__icontains="Measure M ")
         )
 
         qs = qs.prefetch_related(


### PR DESCRIPTION
## Overview

See title.

Connects #1081 

## Testing Instructions

 * Verify that Measure M committees don't appear on the committees page