### PR TITLE
Update archive link and public comment

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -854,6 +854,14 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
             return self.UPCOMING_ECOMMENT_MESSAGE
 
     @property
+    def accepts_public_comment(self):
+        meetings_without_public_comment = {
+            "Special Board Budget Workshop",
+        }
+
+        return self.name not in meetings_without_public_comment
+
+    @property
     def accepts_live_comment(self):
         meetings_without_live_comment = {
             "Measure R Independent Taxpayer Oversight Committee",

--- a/lametro/templates/event/_event_header_no_public_comment.html
+++ b/lametro/templates/event/_event_header_no_public_comment.html
@@ -1,0 +1,34 @@
+<div class="row">
+    {% if has_agenda and not event.has_passed %}
+    <div class="col-sm-7">
+    {% else %}
+    <div class="col-sm-12">
+    {% endif %}
+
+        <p>{{event.description}}</p>
+        <p class="small text-muted">
+            {% if event.status == 'cancelled' %}
+                <strike>
+                <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}<br/>
+                <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}<br/>
+                </strike>
+            {% else %}
+                <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}<br/>
+                <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}<br/>
+                <i class="fa fa-fw fa-map-marker"></i> {{event.location.name}}
+            {% endif %}
+        </p>
+
+        <p class="small">
+            {% if event.web_source.url %}
+                {% if not agenda_url and not uploaded_agenda_url and not uploaded_agenda_pdf %}
+                    Not seeing an agenda? Please use this link:<br>
+                {% endif %}
+                <a href='{{event.web_source.url}}' title='View on the {{CITY_VOCAB.SOURCE}} website' target="_blank">
+                    <i class='fa fa-fw fa-external-link'></i>
+                    View on the {{CITY_VOCAB.SOURCE}} website
+                </a>
+            {% endif %}
+        </p>
+    </div>
+</div>

--- a/lametro/templates/event/event.html
+++ b/lametro/templates/event/event.html
@@ -52,7 +52,9 @@
 
             </h1>
 
-            {% if event.accepts_live_comment %}
+            {% if not event.accepts_public_comment %}
+                {% include 'event/_event_header_no_public_comment.html' %}
+            {% elif event.accepts_live_comment %}
                 {% include 'event/_event_header_live_public_comment.html' %}
             {% else %}
                 {% include 'event/_event_header_no_live_public_comment.html' %}

--- a/lametro/templates/index/index.html
+++ b/lametro/templates/index/index.html
@@ -23,7 +23,7 @@
                 <div class="site-intro-search">
                     {% include 'common/search_bar.html' %}
                 </div>
-                <p class="archive-link"><a href="{% url 'lametro:archive-search' %}">Search the Metro Board Archive from 1952-2015 (Board Boxes 1994-Present)</a></p>
+                <p class="archive-link"><a href="https://mtasearch01.metro.net:23352/apps/boardarchives/">Search the Metro Board Archive from 1952-2015 (Board Boxes 1994-Present)</a></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Overview

This branch updates the archive link below the search bar of the homepage to direct to the mtasearch site.

This also removes the public comment section from Special Board Budget Workshop meetings by including a new model property `accepts_public_comment` and template `_event_header_no_public_comment.html`. The goal with that was to make it easy to mark other meetings that may not accept any public comments in the future. All we'd have to do is add them to the `meetings_without_public_comment` set in the new property.

- Closes #1091
- Closes #1092

### Demo

**Live site (before)**
![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/8ae9c460-7333-4a6b-9a3f-91cecaa437bd)

<hr>

**This branch (after)**
![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/5f5b6685-3c55-43f9-b47e-c54e447edb93)

## Testing Instructions

 * Run an event scrape to make sure you have the Special Board Budget Workshop meeting from a couple weeks ago
   * `docker-compose run --rm scrapers pupa update lametro events window=14 --rpm=0`
 * On the homepage, click the link under the search bar that reads "Search the Metro Board Archive from..."
   * Confirm that it takes you to the usual archive search, the same link described in the issue
 * Head to the Meetings & Agendas search page to find that past meeting
 * Head to its detail page
   * Confirm that the public comment section does not appear

