### PR TITLE
Enable review apps with the staging database

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,9 @@ docker-compose -f docker-compose.yml -f docker-compose.locust.yml run --service-
 This will start the Locust web server on http://localhost:8089. For more details,
 see the [Locust documentation](https://docs.locust.io/en/stable/).
 
+## Review Apps
+This repo is set up to deploy review apps on Heroku, and those pull from the staging database to match the experience of deploying as closely as possible! However, note that in order to prevent unapproved model changes from effecting the staging database, migrations are prevented from running on review apps. So those will still have to be reviewed locally.
+
 ## Errors / Bugs
 
 If something is not behaving intuitively, it is a bug, and should be reported.

--- a/app.json
+++ b/app.json
@@ -4,12 +4,12 @@
   "formation": {
     "web": {
       "quantity": 1,
-      "size": "hobby"
+      "size": "basic"
     }
   },
   "environments": {
     "review": {
-      "addons": ["heroku-postgresql:hobby-basic"]
+      "addons": ["heroku-postgresql:mini"]
     }
   },
   "buildpacks": [],

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
-set -euo pipefail
 
-python manage.py migrate --noinput
-python manage.py createcachetable
-python manage.py import_shapes data/final/boundary.geojson
+if [ -n "${PRODUCTION}" ] || [ -n "${STAGING}" ]; then
+    set -euo pipefail
+
+    python manage.py migrate --noinput
+    python manage.py createcachetable
+    python manage.py import_shapes data/final/boundary.geojson
+    python manage.py clear_cache
+
+else
+    echo "PRODUCTION or STAGING is not set, skipping setup management commands"
+fi


### PR DESCRIPTION
## Overview

This alters the release script to look for either a signal that the app is running on either a production or staging environment.

The staging/production apps on heroku have a new boolean config var added to denote whether setup commands should be run.

Review apps have been set up with config vars nearly identical to the staging environment prior to opening this pr. They are also prepped to use the staging database instead of creating a new one every time a new review app gets made. The change in the release script is meant to prevent potential migrations on review apps from changing the staging db.

Smaller changes include updating the readme and clearing the cache on new releases. The nav would occasionally get formatted strangely and clearing the cache always solves this.

- Closes #1094 

## Testing Instructions

 * Confirm that a review app gets made with the functionality and data available on the staging site.
 * Run `heroku releases:output v6 -a la-metro-cou-feature-re-zibkyf` to see the output of the release marked as "Deploy"
   * Confirm that the output shows `PRODUCTION or STAGING is not set, skipping setup management commands` to note that migrations were not run
