### PR TITLE
Add management command to clear cache

### DIFF
--- a/lametro/management/commands/clear_cache.py
+++ b/lametro/management/commands/clear_cache.py
@@ -1,0 +1,19 @@
+# Adapted from https://github.com/rdegges/django-clear-cache
+from django.conf import settings
+from django.core.cache import cache
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    """A simple management command which clears the site-wide cache."""
+
+    help = "Fully clear your site-wide cache."
+
+    def handle(self, *args, **kwargs):
+        try:
+            assert settings.CACHES
+        except AttributeError:
+            raise CommandError("No cache configured. Check CACHES in settings.py.")
+
+        cache.clear()
+        self.stdout.write("Successfully cleared the cache.")


### PR DESCRIPTION
## Overview

Quick addition of a `clear_cache` command. The newest version of the release script in #1095 uses this command but deploying to staging raises an error because it currently doesn't exist.

## Testing Instructions

 * Run `python manage.py clear_cache` on the review app
 * Confirm that the output ends in a success message
