### PR TITLE
Lower gunicorn timeout

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -14,4 +14,4 @@ release:
   image: web
 # The command that runs your application. Replace 'app' with the name of your app.
 run:
-  web: gunicorn --max-requests 1000 --max-requests-jitter 50 -t 180 --log-level debug councilmatic.wsgi:application
+  web: gunicorn --max-requests 1000 --max-requests-jitter 50 -t 25 --log-level debug councilmatic.wsgi:application

--- a/heroku.yml
+++ b/heroku.yml
@@ -14,4 +14,4 @@ release:
   image: web
 # The command that runs your application. Replace 'app' with the name of your app.
 run:
-  web: gunicorn --max-requests 1000 --max-requests-jitter 50 -t 25 --log-level debug councilmatic.wsgi:application
+  web: gunicorn --max-requests 1000 --max-requests-jitter 50 -t 20 --log-level debug councilmatic.wsgi:application


### PR DESCRIPTION
## Overview

See title. [Heroku recommends a gunicorn timeout of 10-20 seconds.](https://devcenter.heroku.com/articles/preventing-h12-errors-request-timeouts#add-a-timeout-to-the-webserver)

Connects #1109 