### PR TITLE
Optimize homepage loadtime

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -629,8 +629,6 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
             name__icontains="Board Meeting", start_time__gt=timezone.now()
         ).order_by("start_time")
 
-        next_meeting = board_meetings.first()
-
         if board_meetings.exists():
             next_meeting = board_meetings.first()
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -87,7 +87,7 @@ class LAMetroIndexView(IndexView):
     event_model = LAMetroEvent
 
     def get_context_data(self, **kwargs):
-        context = super(IndexView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
 
         context["upcoming_board_meetings"] = self.event_model.upcoming_board_meetings()[
             :2

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -86,26 +86,27 @@ class LAMetroIndexView(IndexView):
 
     event_model = LAMetroEvent
 
-    @property
-    def extra_context(self):
-        extra = {}
+    def get_context_data(self, **kwargs):
+        context = super(IndexView, self).get_context_data(**kwargs)
 
-        extra["upcoming_board_meetings"] = self.event_model.upcoming_board_meetings()[
+        context["upcoming_board_meetings"] = self.event_model.upcoming_board_meetings()[
             :2
         ]
-        extra["most_recent_past_meetings"] = (
+        context["most_recent_past_meetings"] = (
             self.event_model.most_recent_past_meetings()
         )
-        extra["current_meeting"] = self.event_model.current_meeting()
-        extra["bilingual"] = bool([e for e in extra["current_meeting"] if e.bilingual])
-        extra["USING_ECOMMENT"] = settings.USING_ECOMMENT
+        context["current_meeting"] = self.event_model.current_meeting()
+        context["bilingual"] = bool(
+            [e for e in context["current_meeting"] if e.bilingual]
+        )
+        context["USING_ECOMMENT"] = settings.USING_ECOMMENT
 
-        extra["todays_meetings"] = self.event_model.todays_meetings().order_by(
+        context["todays_meetings"] = self.event_model.todays_meetings().order_by(
             "start_date"
         )
-        extra["form"] = LAMetroCouncilmaticSearchForm()
+        context["form"] = LAMetroCouncilmaticSearchForm()
 
-        return extra
+        return context
 
 
 class LABillDetail(BillDetailView):


### PR DESCRIPTION
## Overview

This PR optimizes the homepage by:

- caching calls to Granicus' streaming meeting endpoint
- fixing a bug where the homepage context was being computed twice (fixed by using `get_context_data` for the home view)
- using `prefetch_related` and `select_related` to make database calls more efficient

Locally, I saw the number of SQL queries halve (~30 vs ~60) on the homepage. 

Connects #1109

## Testing Instructions

 * Verify tests pass
 * Make sure everything on the homepage looks as expected

We'll get a clearer view of the performance improvements in production by consulting Sentry's metrics.
