### PR TITLE
Reduce homepage db queries

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -607,9 +607,9 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
 
         meetings_in_past_two_weeks = (
             cls.objects.with_media()
-            .prefetch_related("broadcast")
             .filter(start_time__gte=two_weeks_ago)
             .order_by("-start_time")
+            .prefetch_related("broadcast")
         )
 
         # since has_passed is a property of LAMetroEvent rather than
@@ -840,14 +840,10 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
 
     @property
     def has_passed(self):
-        try:
-            event_broadcast = self.broadcast.get()
+        if self.broadcast.exists():
+            return self.broadcast.get().observed and not self.is_ongoing
 
-        except EventBroadcast.DoesNotExist:
-            return False
-
-        else:
-            return event_broadcast.observed and not self.is_ongoing
+        return False
 
     @property
     def ecomment_url(self):


### PR DESCRIPTION
## Overview

This PR:
- optimizes the homepage by removing unnecessary database queries in the`LAMetroEvent.has_passed` property
- reduces noise in Sentry by no longer tracking performance of static asset pages

Connects #1109 

## Testing Instructions

 * Verify that tests pass
