### PR TITLE
Optimize database calls on index and event detail page

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -838,7 +838,7 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
     def is_ongoing(self):
         return self in type(self)._streaming_meeting()
 
-    @property
+    @cached_property
     def has_passed(self):
         if self.broadcast.exists():
             return self.broadcast.get().observed and not self.is_ongoing
@@ -893,7 +893,7 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
 
         return cls.objects.filter(
             start_time__gte=today_utc, start_time__lt=tomorrow_utc
-        )
+        ).prefetch_related("broadcast", "location")
 
     @property
     def display_status(self):

--- a/lametro/templates/event/_event_header_live_public_comment.html
+++ b/lametro/templates/event/_event_header_live_public_comment.html
@@ -38,11 +38,11 @@
         {% endif %}
 
         <p class="small">
-            {% if event.web_source.url %}
+            {% if web_source_url %}
                 {% if not agenda_url and not uploaded_agenda_url and not uploaded_agenda_pdf %}
                     Not seeing an agenda? Please use this link:<br>
                 {% endif %}
-                <a href='{{event.web_source.url}}' title='View on the {{CITY_VOCAB.SOURCE}} website' target="_blank">
+                <a href='{{web_source_url}}' title='View on the {{CITY_VOCAB.SOURCE}} website' target="_blank">
                     <i class='fa fa-fw fa-external-link'></i>
                     View on the {{CITY_VOCAB.SOURCE}} website
                 </a>

--- a/lametro/templates/event/event.html
+++ b/lametro/templates/event/event.html
@@ -189,7 +189,7 @@
                     {% endif %}
                 </div>
                 <div class="col-md-5">
-                    {% if event.documents.all %}
+                    {% if documents %}
                         {% include 'event/_related_bills.html' %}
                     {% endif %}
                 </div>

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -216,8 +216,9 @@ class LAMetroEventDetail(EventDetailView):
         )
 
         # Find agenda link.
-        if event.documents.all():
-            for document in event.documents.all():
+        documents = event.documents.prefetch_related("links").all()
+        if documents:
+            for document in documents:
                 if "Agenda" in document.note:
                     context["agenda_url"] = document.links.first().url
                     context["document_timestamp"] = document.date

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -312,6 +312,7 @@ def test_streamed_meeting_is_marked_as_broadcast(concurrent_current_meetings, mo
     # is still upcoming, since it has not yet broadcast.
     with freeze_time(LAMetroEvent._time_from_now(hours=1)):
         mock_response.json.return_value = []
+        del test_event_a.has_passed
 
         assert test_event_a.has_passed
         assert not any([test_event_a.is_upcoming, test_event_a.is_ongoing])
@@ -457,6 +458,7 @@ def test_event_is_upcoming(event, mocker):
     test_event.save()
 
     with freeze_time(tomorrow_morning):
+        del test_event.has_passed
         assert not test_event.is_upcoming
 
 


### PR DESCRIPTION
## Overview

This PR removes duplicate database calls on the index and event detail pages. Specifically, it tackles database logic that's activated when there are meetings "today."

Locally, on a day with 4 meetings, homepage database queries reduced by 50% (44 -> 22) and event detail page queries reduced by ~35% (17 -> 11).

Connects #1109 

## Testing Instructions

 * Verify tests pass
