### PR TITLE
Optimize person detail page

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -409,7 +409,7 @@ class LAMetroPerson(Person, SourcesMixin):
 
         return office_membership
 
-    @cached_property
+    @property
     def committee_sponsorships(self):
         """
         This property returns a list of five bills, which have recent actions

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -358,7 +358,7 @@ class LAMetroPerson(Person, SourcesMixin):
     def slug_name(self):
         return slugify(self.name)
 
-    @property
+    @cached_property
     def latest_council_membership(self):
         filter_kwarg = {
             "organization__name": settings.OCD_CITY_COUNCIL_NAME,

--- a/lametro/templates/person/person.html
+++ b/lametro/templates/person/person.html
@@ -64,9 +64,9 @@
                 <div id='map-detail'></div>
             {% endif %}
 
-            {% if person.headshot_source %}
+            {% if headshot_source %}
                 <p class='small'>
-                    <i class='fa fa-fw fa-camera'></i> Credit: {{person.headshot_source}}
+                    <i class='fa fa-fw fa-camera'></i> Credit: {{ headshot_source }}
                 </p>
             {% endif %}
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -707,7 +707,8 @@ class LAPersonDetailView(PersonDetailView):
             context["sponsored_legislation"] = []
 
         context["memberships_list"] = (
-            person.current_memberships.exclude(organization__name="Board of Directors")
+            person.current_memberships.prefetch_related("organization")
+            .exclude(organization__name="Board of Directors")
             .annotate(
                 index=Case(
                     When(role="Chair", then=Value(0)),
@@ -729,6 +730,8 @@ class LAPersonDetailView(PersonDetailView):
             context["website_url"] = person.links.get(note="web_site").url
         except PersonLink.DoesNotExist:
             pass
+
+        context["headshot_source"] = person.headshot_source
 
         return context
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -701,8 +701,9 @@ class LAPersonDetailView(PersonDetailView):
         except AttributeError:
             context["map_geojson"] = None
 
-        if person.committee_sponsorships:
-            context["sponsored_legislation"] = person.committee_sponsorships
+        sponsored_legislation = list(person.committee_sponsorships.iterator())
+        if sponsored_legislation:
+            context["sponsored_legislation"] = sponsored_legislation
         else:
             context["sponsored_legislation"] = []
 


### PR DESCRIPTION
## Overview

See title. Locally, I saw database calls on person detail pages reduce by about half. 

## Notes

Evaluating the Queryset returned by `LAMetroPerson.committee_sponsorships` on Heroku takes anywhere from several minutes to sometimes 10+ seconds (along with spiking memory usage). Since we're only evaluating the Queryset once, I dropped in a [iterator](https://docs.djangoproject.com/en/3.2/ref/models/querysets/#iterator) to see if the lack of caching can improve the performance.

Connects #1109

## Testing Instructions

 * Verify tests pass
