### PR TITLE
Cap running events request

### DIFF
--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -272,3 +272,6 @@ MARKDOWNIFY = {
         ]
     }
 }
+
+# Hard time limit on HTTP requests
+REQUEST_TIMEOUT = 5

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -40,7 +40,7 @@ from councilmatic_core.models import (
 from lametro.utils import (
     format_full_text,
     parse_subject,
-    get_url,
+    timed_get,
     LAMetroRequestTimeoutException,
 )
 from councilmatic.settings_jurisdiction import BILL_STATUS_DESCRIPTIONS, MEMBER_BIOS
@@ -62,7 +62,7 @@ class SourcesMixin(object):
     @property
     def api_representation(self):
         try:
-            response = get_url(self.api_source.url)
+            response = timed_get(self.api_source.url)
             response.raise_for_status()
 
         except (LAMetroRequestTimeoutException, requests.Timeout):
@@ -552,7 +552,7 @@ class LiveMediaMixin(object):
 
     def _valid(self, media_url):
         try:
-            response = get_url(media_url)
+            response = timed_get(media_url)
         except (LAMetroRequestTimeoutException, requests.Timeout):
             return False
 
@@ -712,7 +712,9 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
         running_events = cache.get("running_events")
         if not running_events:
             try:
-                running_events = get_url("http://metro.granicus.com/running_events.php")
+                running_events = timed_get(
+                    "http://metro.granicus.com/running_events.php"
+                )
 
             except (LAMetroRequestTimeoutException, requests.RequestException) as e:
                 logger.warning(e)

--- a/lametro/utils.py
+++ b/lametro/utils.py
@@ -115,14 +115,14 @@ class LAMetroRequestTimeoutException(Exception):
     pass
 
 
-def get_url(url, params=None, **kwargs):
+def timed_get(url, params=None, **kwargs):
     """
     Convenience function to ensure GET requests that time out raise an exception.
 
     See https://stackoverflow.com/a/71453648
     """
 
-    TOTAL_TIMEOUT = kwargs.get("timeout", 5)
+    TOTAL_TIMEOUT = kwargs.get("timeout", getattr(settings, "REQUEST_TIMEOUT"))
 
     def trace_function(frame, event, arg):
         """

--- a/lametro/utils.py
+++ b/lametro/utils.py
@@ -112,7 +112,8 @@ def get_list_from_csv(filename):
 
 
 class LAMetroRequestTimeoutException(Exception):
-    pass
+    def __init__(self, url, timeout):
+        super().__init__(f"Request to {url} took longer than {timeout} seconds.")
 
 
 def timed_get(url, params=None, **kwargs):
@@ -122,7 +123,7 @@ def timed_get(url, params=None, **kwargs):
     See https://stackoverflow.com/a/71453648
     """
 
-    TOTAL_TIMEOUT = kwargs.get("timeout", getattr(settings, "REQUEST_TIMEOUT"))
+    TOTAL_TIMEOUT = kwargs.get("timeout", settings.REQUEST_TIMEOUT)
 
     def trace_function(frame, event, arg):
         """
@@ -130,7 +131,7 @@ def timed_get(url, params=None, **kwargs):
         start to finish exceeds TOTAL_TIMEOUT.
         """
         if time.time() - start > TOTAL_TIMEOUT:
-            raise LAMetroRequestTimeoutException("Request timed out.")
+            raise LAMetroRequestTimeoutException(url, TOTAL_TIMEOUT)
 
         return trace_function
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,0 +1,16 @@
+import pytest
+from freezegun import freeze_time
+from datetime import datetime, timezone, timedelta
+
+from lametro.utils import get_url, LAMetroRequestTimeoutException
+
+
+def test_get_url(mocker):
+    ten_seconds_ago = datetime.now(tz=timezone.utc) - timedelta(seconds=20)
+    with pytest.raises(LAMetroRequestTimeoutException):
+        with freeze_time(ten_seconds_ago):
+            get_url("https://google.com", timeout=5)
+
+    one_second_ago = datetime.now(tz=timezone.utc) - timedelta(seconds=0)
+    with freeze_time(one_second_ago):
+        get_url("https://google.com", timeout=5)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2,15 +2,15 @@ import pytest
 from freezegun import freeze_time
 from datetime import datetime, timezone, timedelta
 
-from lametro.utils import get_url, LAMetroRequestTimeoutException
+from lametro.utils import timed_get, LAMetroRequestTimeoutException
 
 
-def test_get_url(mocker):
+def test_timed_get(mocker):
     ten_seconds_ago = datetime.now(tz=timezone.utc) - timedelta(seconds=20)
     with pytest.raises(LAMetroRequestTimeoutException):
         with freeze_time(ten_seconds_ago):
-            get_url("https://google.com", timeout=5)
+            timed_get("https://google.com", timeout=5)
 
-    one_second_ago = datetime.now(tz=timezone.utc) - timedelta(seconds=0)
+    one_second_ago = datetime.now(tz=timezone.utc) - timedelta(seconds=1)
     with freeze_time(one_second_ago):
-        get_url("https://google.com", timeout=5)
+        timed_get("https://google.com", timeout=5)


### PR DESCRIPTION
## Overview

Granicus seems to be having intermittent issues with their running meetings endpoint. This PR aims to put a hard limit on requests to Granicus to make sure that our pages remain accessible regardless of the status of the running meetings endpoint.

Connects #1118

## Testing Instructions

 * Verify that tests pass
 * Verify that the review app's homepage works correctly
