### PR TITLE
Fix missing agenda list items

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,8 @@ jobs:
         python-version: '3.10'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools
+        python -m pip install pip==24.0
+        pip install --upgrade setuptools
         pip install -r requirements.txt
     - name: Test with pytest
       env:
@@ -64,4 +65,3 @@ jobs:
         flake8 .
         black --check .
         pytest -sv
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN mkdir /app
 WORKDIR /app
 
 COPY ./requirements.txt /app/requirements.txt
-RUN pip install --upgrade pip setuptools && \
+RUN pip install pip==24.0 \
+RUN pip install --upgrade setuptools && \
     pip install --no-cache-dir -r requirements.txt
 
 COPY . /app
@@ -35,4 +36,3 @@ COPY --from=builder /usr/local/bin/_stack_lib.sh /usr/local/bin/
 RUN DJANGO_SETTINGS_MODULE=councilmatic.minimal_settings python manage.py collectstatic
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN mkdir /app
 WORKDIR /app
 
 COPY ./requirements.txt /app/requirements.txt
-RUN pip install pip==24.0 \
-RUN pip install --upgrade setuptools && \
+RUN pip install pip==24.0 && \
+    pip install --upgrade setuptools && \
     pip install --no-cache-dir -r requirements.txt
 
 COPY . /app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 FROM ghcr.io/metro-records/la-metro-councilmatic:main
 
 COPY ./requirements.txt /app/requirements.txt
-RUN pip install --upgrade pip && \
+RUN pip install pip==24.0 && \
     pip install --no-cache-dir -r requirements.txt

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -243,6 +243,7 @@ class LAMetroEventDetail(EventDetailView):
                     preventing the browser from retrieving a cached
                     iframe, when the timestamp changes.
                     """
+        context["documents"] = documents
 
         context["related_board_reports"] = agenda_with_board_reports
         context["base_url"] = PIC_BASE_URL  # Give JS access to this variable


### PR DESCRIPTION
## Overview

This branch gives the event detail template access to the `documents` variable which it was expecting in order to render the `_related_bills` partial. This should allow the related board reports to show up again.

This also pins the version of pip used in docker to `24.0`. Version `24.1` was recently released (June 20th) and only allows pinning packages with an asterisk when using `==` or `!=` . Something like `package-name<=1.2.*` no longer works, which is what `textract` tries to do with one of its dependencies.

- Connects #1121

## Testing Instructions

 * Head to a past event's detail page within the review app
 * Confirm that the Board Reports heading appears as expected
 * Confirm that related bills show up if available
