### PR TITLE
Prevent manual broadcast button from appearing when one exists

### DIFF
--- a/lametro/templates/event/event.html
+++ b/lametro/templates/event/event.html
@@ -42,6 +42,8 @@
                     {% endfor %}
                 {% endif %}
                 {% if user.is_authenticated %}
+                    {% get_events_with_manual_broadcasts as manual_events %}
+
                     {% if not event_ok %}
                         <div class="well" style="margin-top: 20px">
                             <p>This event does not exist in Legistar. It may have been deleted from Legistar due to being a duplicate. To delete this event, click the button below.</p>

--- a/lametro/templates/event/event.html
+++ b/lametro/templates/event/event.html
@@ -42,39 +42,44 @@
                     {% endfor %}
                 {% endif %}
                 {% if user.is_authenticated %}
-
-                    <div class="well" style="margin-top: 20px">
-                        {% if not event_ok %}
+                    {% if not event_ok %}
+                        <div class="well" style="margin-top: 20px">
                             <p>This event does not exist in Legistar. It may have been deleted from Legistar due to being a duplicate. To delete this event, click the button below.</p>
                             <a href="{% url 'delete_event' event.slug %}" class='btn btn-teal' style="margin-bottom: 20px"><i class="fa fa-times" aria-hidden="true"></i> Delete Event</a>
-                        {% elif not event.has_manual_broadcast and manual_events|length >= 1 %}
-                            <p>
-                                Please unpublish any existing manually live links before publishing this one.
-                                The following event already has a manual broadcast at the moment:
-                            </p>
-                            <ul>
-                                {% for m_event in manual_events %}
-                                    <li style="font-size:16px">
-                                        <a href="/event/{{m_event.slug}}">{{m_event.name}}</a>
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                            <button class='btn btn-teal' disabled style="margin-bottom: 20px"><i class="fa fa-headphones" aria-hidden="true"></i> Publish Watch Live Link</button>
-                        {% elif not event.has_manual_broadcast %}
-                            <p>
-                                You can manually publish a "Watch Live" link for this meeting if needed.
-                                Once the scheduled end time has passed, you will be responsible for undoing this change.
-                                Please be advised that this should only be done if Legistar is currently unavailable.
-                            </p>
-                            <a href="{% url 'manual_event_live_link' event.slug %}" class="btn btn-teal"><i class= "fa fa-headphones" aria-hidden="true"></i> Publish Watch Live Link</a>
-                        {% else %}
-                            <p>
-                                This meeting currently has a manually published "Watch Live" link.
-                                Once the scheduled end time has passed, you will be responsible for unpublishing this link.
-                            </p>
-                            <a href="{% url 'manual_event_live_link' event.slug %}" class="btn btn-teal"><i class= "fa fa-headphones" aria-hidden="true"></i> Unpublish Watch Live Link</a>
-                        {% endif %}
-                    </div>
+                        </div>
+                    {% elif event.status != 'cancelled' %}
+                        <div class="well" style="margin-top: 20px">
+                            {% if event.media.all.exists %}
+                                <p>This event has a proper broadcast link, and cannot have a manual broadcast published.</p>
+                            {% elif not event.has_manual_broadcast and manual_events|length >= 1 %}
+                                <p>
+                                    Please unpublish any existing manually live links before publishing this one.
+                                    The following event already has a manual broadcast at the moment:
+                                </p>
+                                <ul>
+                                    {% for m_event in manual_events %}
+                                        <li style="font-size:16px">
+                                            <a href="/event/{{m_event.slug}}">{{m_event.name}}</a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                                <button class='btn btn-teal' disabled style="margin-bottom: 20px"><i class="fa fa-headphones" aria-hidden="true"></i> Publish Watch Live Link</button>
+                            {% elif not event.has_manual_broadcast %}
+                                <p>
+                                    You can manually publish a "Watch Live" link for this meeting if needed.
+                                    Once the scheduled end time has passed, you will be responsible for undoing this change.
+                                    Please be advised that this should only be done if Legistar is currently unavailable.
+                                </p>
+                                <a href="{% url 'manual_event_live_link' event.slug %}" class="btn btn-teal"><i class= "fa fa-headphones" aria-hidden="true"></i> Publish Watch Live Link</a>
+                            {% else %}
+                                <p>
+                                    This meeting currently has a manually published "Watch Live" link.
+                                    Once the scheduled end time has passed, you will be responsible for unpublishing this link.
+                                </p>
+                                <a href="{% url 'manual_event_live_link' event.slug %}" class="btn btn-teal"><i class= "fa fa-headphones" aria-hidden="true"></i> Unpublish Watch Live Link</a>
+                            {% endif %}
+                        </div>
+                    {% endif %}
                 {% endif %}
 
             </h1>


### PR DESCRIPTION
## Overview

This is a fix for a bug in pr #1112. On staging, the logic for preventing a user from publishing another broadcast when one already existed was not working because the `manual_events` variable that the event template was expecting didn't exist. This sets that up properly.

This also disallows the option to publish a manual broadcast both for past events that already have a regular broadcast available, and cancelled events.

## Testing Instructions
**Note: since that last PR applied the migration for manual broadcasts, this can now be tested on the review app (using the staging database)

 * Publish an event
 * Go to another event's page. Confirm that:
   * An event **without** a proper broadcast does not allow publishing a second one, and provides a link to the initial event
   * An event **with** a proper broadcast or a **cancelled** event does not allow publishing a new one at all