### PR TITLE
Handle proper broadcast becoming avail while there's a manual one

### DIFF
--- a/lametro/templates/event/event.html
+++ b/lametro/templates/event/event.html
@@ -51,7 +51,13 @@
                         </div>
                     {% elif event.status != 'cancelled' %}
                         <div class="well" style="margin-top: 20px">
-                            {% if event.media.all.exists %}
+                            {% if event.has_manual_broadcast and event.media.all.exists %}
+                                <p>
+                                    This event now has a proper broadcast link, and the previous manual broadcast can now be unpublished.
+                                    Please unpublish the manual link.
+                                </p>
+                                <a href="{% url 'manual_event_live_link' event.slug %}" class="btn btn-teal"><i class= "fa fa-headphones" aria-hidden="true"></i> Unpublish Watch Live Link</a>
+                            {% elif event.media.all.exists %}
                                 <p>This event has a proper broadcast link, and cannot have a manual broadcast published.</p>
                             {% elif not event.has_manual_broadcast and manual_events|length >= 1 %}
                                 <p>


### PR DESCRIPTION
## Overview

This accounts for the edge case where an event with a manually published broadcast link gets access to a proper broadcast link. Previously, the conditionals in the event template would hide the option to unpublish a link if a proper link was available, making it difficult to unpublish that event's manual broadcast if it existed. This allows for that button to be available if both a manual and proper broadcast link exist.

- Connects #1133

### Notes

The connected issue describes two improvements, but I'll do this one first because it'll be easier to test now before the second improvement comes in.

## Testing Instructions
 * Log in to the review app
 * Find an event with a proper broadcast and use the manual broadcast url to publish a link for it
   * Can use the event: https://la-metro-cou-patch-manu-sjjazy.herokuapp.com/event/regular-board-meeting-c46ed85d722f/
   * And the publish manual broadcast url: https://la-metro-cou-patch-manu-sjjazy.herokuapp.com/manual_event_link/regular-board-meeting-c46ed85d722f/
 * Head back to that event's detail page and attempt to unpublish the link
   * Confirm that the message above the unpublish button appropriately describes the situation
   * Confirm that the link gets unpublished
