### PR TITLE
Prevent broadcast creation if a proper one already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ debug.log
 
 lametro/secrets.py
 .env.local
+
+.venv

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -316,15 +316,22 @@ def manual_event_live_link(request, event_slug):
     Toggle a manually live event broadcast link
     """
     event = LAMetroEvent.objects.get(slug=event_slug)
-    broadcasts = event.broadcast.filter(is_manually_live=True)
+    has_regular_broadcasts = event.broadcast.filter(is_manually_live=False).exists()
+    manual_broadcasts = event.broadcast.filter(is_manually_live=True)
 
-    if broadcasts.count() == 0:
+    if manual_broadcasts.count() == 0 and not has_regular_broadcasts:
         # Create a manual broadcast
         EventBroadcast.objects.create(event=event, is_manually_live=True)
         messages.success(request, f"Link for {event.name} has been manually published.")
+    elif has_regular_broadcasts:
+        messages.info(
+            request,
+            f"The event {event.name} already has a proper broadcast. "
+            + f"A manual broadcast cannot be created.",
+        )
     else:
         # Delete that broadcast
-        for b in broadcasts:
+        for b in manual_broadcasts:
             b.delete()
         messages.success(request, f"Link for {event.name} has been unpublished.")
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -327,7 +327,7 @@ def manual_event_live_link(request, event_slug):
         messages.info(
             request,
             f"The event {event.name} already has a proper broadcast. "
-            + f"A manual broadcast cannot be created.",
+            + "A manual broadcast cannot be created.",
         )
     else:
         # Delete that broadcast

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -763,7 +763,7 @@ def test_manual_broadcast_permissions(event, client, admin_client, mocker):
     """
     Check that only authenticated users can make/delete manual broadcasts
     """
-    test_event = event.build()
+    test_event = event.build(has_broadcast=False)
     mock_api_representation = mocker.patch(
         "lametro.models.SourcesMixin.api_representation",
         new_callable=mocker.PropertyMock,
@@ -803,7 +803,7 @@ def test_manually_broadcasted_events(event, admin_client, mocker):
     """
     Check that events marked as having a manual broadcast are counted as being current/live.
     """
-    test_event = event.build()
+    test_event = event.build(has_broadcast=False)
     mock_api_representation = mocker.patch(
         "lametro.models.SourcesMixin.api_representation",
         new_callable=mocker.PropertyMock,


### PR DESCRIPTION
## Overview

This branch prevents users from creating a manual broadcast using the event's link if a proper broadcast already exists.

The format for the link that toggles a manual broadcast is `https://boardagendas.metro.net/manual_event_link/<event_slug>` which could be accessed accidentally/easily. So this is just an extra measure to ensure that users can't get into a situation where they've made a manual broadcast for an event that didn't need one.

- Closes #1133

### Demo

![image](https://github.com/user-attachments/assets/0cf5ab5c-f556-46ad-a06e-e7d5cd8a2dea)


## Testing Instructions
 * Log in to the review app
 * Head to an event that already has a broadcast link
 * Try to use the event's slug in the url to create your own manual broadcast link
   * For this review app, it would look like `https://la-metro-cou-patch-manu-wjk6yq.herokuapp.com/manual_event_link/<event_slug>`
   * Confirm that a manual broadcast does not get created
   * Confirm that a message appears that explains that the event cannot have a manual broadcast at this point
