### PR TITLE
Handle invalid facet formatting, closes #1144

### DIFF
--- a/lametro/views.py
+++ b/lametro/views.py
@@ -793,7 +793,11 @@ class LAMetroCouncilmaticFacetedSearchView(CouncilmaticFacetedSearchView):
 
         for val in self.request.GET.getlist("selected_facets"):
             if val:
-                [k, v] = val.split("_exact:", 1)
+                try:
+                    [k, v] = val.split("_exact:", 1)
+                except ValueError:
+                    continue
+
                 try:
                     selected_facets[k].append(v)
                 except KeyError:


### PR DESCRIPTION
## Overview

See title.

Connects #1144 

## Testing Instructions
- Using the deploy preview, run a search.
- Append the following to your search URL and re-run it: `&selected_facets=3712`
- Confirm the site doesn't break.