### PR TITLE
Handle connection error in api_representation, closes #1143

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -75,6 +75,10 @@ class SourcesMixin(object):
             )
             return None
 
+        except requests.ConnectionError:
+            logger.warning(f"Request to {self.api_source.url} disconnected.")
+            return None
+
         return response.json()
 
 


### PR DESCRIPTION
## Overview

See title.

Connects #1143

## Testing Instructions

Not sure. Did we do testing for the `timed_get` PR, @antidipyramid?