### PR TITLE
Reverse order of cache doc parameters, closes #1149

### DIFF
--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -58,7 +58,7 @@ def prepare_title(full_text):
 
 @register.filter
 def full_text_doc_url(url):
-    query = {"document_url": url, "filename": "agenda"}
+    query = {"filename": "agenda", "document_url": url}
     pic_query = {"file": PIC_BASE_URL + "?" + urllib.parse.urlencode(query)}
 
     return urllib.parse.urlencode(pic_query)


### PR DESCRIPTION
## Overview

See title.

Connects #1149

## Testing Instructions

- On the deploy preview, view some board report pages and confirm the agenda document renders correctly in the PDF viewer.
