### PR TITLE
Don't store full text in search index

### DIFF
--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -12,6 +12,7 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
     attachment_text = indexes.CharField()
     viewable = indexes.BooleanField()
     identifier = indexes.CharField(model_attr="identifier", boost=3.0)
+    full_text = indexes.CharField(stored=False, model_attr="full_text", default="")
 
     # Custom Metro facets
     bill_type = indexes.MultiValueField(faceted=True)


### PR DESCRIPTION
## Overview

This PR overrides `django-councilmatic`'s `BillIndex.full_text` to no longer store a board report's `full_text` in the index.

Connects #1151 

## Testing Instructions

This PR requires an index rebuild and should be tested locally. 

* Run `docker compose run --rm app python manage.py rebuild_index`
* Verify that search still works as expected

Once this is merged in, I'll rebuild the staging database's index and see if this addresses our memory problems when searching.