### PR TITLE
Add configuration to suppress live media for specified events

### DIFF
--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -12,6 +12,7 @@ env = environ.Env(
     DJANGO_SECRET_KEY=(str, "replacethiswithsomethingsecret"),
     DJANGO_DEBUG=(bool, True),
     DJANGO_ALLOWED_HOSTS=(list, ["localhost", "127.0.0.1", "0.0.0.0"]),
+    COUNCILMATIC_SUPPRESS_LIVE_MEDIA=(list, []),
     DATABASE_URL=(str, "postgis://postgres:postgres@postgres:5432/lametro"),
     SEARCH_URL=(str, "http://elasticsearch:9200"),
     SHOW_TEST_EVENTS=(bool, False),
@@ -49,6 +50,7 @@ SECRET_KEY = env("DJANGO_SECRET_KEY")
 DEBUG = env.bool("DJANGO_DEBUG")
 SHOW_TEST_EVENTS = env.bool("SHOW_TEST_EVENTS")
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS")
+COUNCILMATIC_SUPPRESS_LIVE_MEDIA = env.list("COUNCILMATIC_SUPPRESS_LIVE_MEDIA")
 
 if env("LOCAL_DOCKER"):
     import socket

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -563,6 +563,9 @@ class LiveMediaMixin(object):
 
     @property
     def english_live_media_url(self):
+        if self.slug in settings.COUNCILMATIC_SUPPRESS_LIVE_MEDIA:
+            return None
+
         guid = self.extras["guid"]
         english_url = self.BASE_MEDIA_URL + "event_id={guid}".format(guid=guid)
 
@@ -573,6 +576,9 @@ class LiveMediaMixin(object):
 
     @property
     def spanish_live_media_url(self):
+        if self.slug in settings.COUNCILMATIC_SUPPRESS_LIVE_MEDIA:
+            return None
+
         """
         If there is not an associated Spanish event, there will not be
         Spanish audio for the event, e.g., return None.
@@ -704,7 +710,6 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
         Hit the endpoint, and return the corresponding meeting, or an empty
         queryset.
         """
-
         running_events = cache.get("running_events")
         if not running_events:
             try:

--- a/lametro/templates/event/event.html
+++ b/lametro/templates/event/event.html
@@ -24,7 +24,7 @@
                     {{event.name}}
                 {% endif %}
 
-                {% if event.is_ongoing %}
+                {% if event.is_ongoing and event.english_live_media_url %}
                     <a class="btn btn-salmon" href="{{ event.english_live_media_url }}" target="_blank">
                         <i class="fa fa-headphones" aria-hidden="true"></i>
                         Watch in English

--- a/lametro/templates/index/_meeting_details_current.html
+++ b/lametro/templates/index/_meeting_details_current.html
@@ -87,17 +87,19 @@
 				<!-- Buttons -->
 				<div class="text-center">
 					<div style="display:inline-block;">
-						<a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" >
-							<i class="fa fa-headphones" aria-hidden="true"></i>
-							Watch in English
-						</a>
+                        {% if current_meeting.first.english_live_media_url %}
+    						<a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" >
+    							<i class="fa fa-headphones" aria-hidden="true"></i>
+    							Watch in English
+    						</a>
 
-						{% if bilingual %}
-						<a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank">
-							<i class="fa fa-headphones" aria-hidden="true"></i>
-							Ver en Español
-						</a>
-						{% endif %}
+    						{% if bilingual %}
+    						<a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank">
+    							<i class="fa fa-headphones" aria-hidden="true"></i>
+    							Ver en Español
+    						</a>
+    						{% endif %}
+                        {% endif %}
 
 						{% if USING_ECOMMENT %}
 							<a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.ecomment_url }}" target="_blank">
@@ -119,4 +121,3 @@
         {% endif %}
     </div>
 </div>
-


### PR DESCRIPTION
## Overview

See title.

Connects to a support email. 

## Testing Instructions

This patch was deployed to staging for testing, then to prod as a hot fix ahead of today's meeting.
