### PR TITLE
Account for multiple minutes

### DIFF
--- a/lametro/templates/event/event.html
+++ b/lametro/templates/event/event.html
@@ -145,10 +145,15 @@
 
                         {% if event.start_time|compare_time %}
                             {% if minutes %}
-                            <h4>Minutes</h4>
-                            <p>
-                                <a href="{{ minutes.links.get.url }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
-                            </p>
+                                <h4>Minutes</h4>
+
+                                {% for m in minutes %}
+                                    <p>
+                                        <a href="{{ m.links.get.url }}"><i class="fa fa-calendar" aria-hidden="true"></i>
+                                            View Minutes {% if minutes.count > 1 %}#{{ forloop.counter}}{% endif %}
+                                        </a>
+                                    </p>
+                                {% endfor %}
                             {% endif %}
                         {% endif %}
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -206,7 +206,7 @@ class LAMetroEventDetail(EventDetailView):
                 context["event_ok"] = False
 
         try:
-            context["minutes"] = event.documents.get(note__icontains="minutes")
+            context["minutes"] = event.documents.filter(note__icontains="minutes")
         except EventDocument.DoesNotExist:
             pass
 


### PR DESCRIPTION
## Overview

This branch is one of two changes needed to resolve [issue #16 in the scrapers repo](https://github.com/Metro-Records/scrapers-lametro/issues/16). Once the scrapers allow for multiple meeting minutes to be saved, this branch will provide a way to show those multiple minutes.

- Connects: https://github.com/Metro-Records/scrapers-lametro/issues/16
- Related scrapers PR: https://github.com/Metro-Records/scrapers-lametro/pull/23

### Demo

![image](https://github.com/user-attachments/assets/38d4214c-37cf-4b37-9e44-d52cfd9d4754)

### Notes

This should most likely be merged in before the corresponding pr in the scrapers repo since this would not introduce breaking changes by itself.

## Testing Instructions
 * Head to the review app
 * Find a meeting with a minutes file
 * Confirm that meetings with a minutes file still display the link as normal
   * Note: we can test whether this works with multiple minutes when the related scrapers PR comes in
