### PR TITLE
Fix logic to populate agenda viewer on non-mobile devices

### DIFF
--- a/lametro/templates/event/event.html
+++ b/lametro/templates/event/event.html
@@ -164,8 +164,7 @@
                         frameborder="0"
                         seamless="true"
                         width="100%"
-                        height="600px"
-                        src={% if agenda_url %}"/pdfviewer/?{{agenda_url|full_text_doc_url}}"{% elif uploaded_agenda_url %}"/pdfviewer/?{{uploaded_agenda_url|full_text_doc_url}}"{% elif uploaded_agenda_pdf %}"{% static uploaded_agenda_pdf %}"{% endif %}>
+                        height="600px">
                     </iframe>
 
                     {% else %}
@@ -276,6 +275,23 @@
             $('#pdf-form-message, #pdf-check-viewer-test, #pdf-form-cancel, #pdf-form-submit').addClass('hidden');
         });
     });
+
+     if (window.innerWidth > 768){
+        {% if agenda_url %}
+            const agendaUrl = "/pdfviewer/?{{agenda_url|full_text_doc_url}}"
+        {% elif uploaded_agenda_url %}
+            const agendaUrl = "/pdfviewer/?{{uploaded_agenda_url|full_text_doc_url}}"
+        {% elif uploaded_agenda_pdf %}
+            const agendaUrl = "{% static uploaded_agenda_pdf %}"
+        {% endif %}
+
+        $("#pdf-embed-agenda").attr("src", agendaUrl);
+    }
+    else{
+        $('#pdf-embed-agenda').hide()
+        $('#pdf-download-link').html("<i class='fa fa-fw fa-external-link'></i> View PDF")
+    }
+
     {% for source in event.sources.all %}
         console.log('source: {{source}}');
     {% endfor %}

--- a/lametro/templates/legislation.html
+++ b/lametro/templates/legislation.html
@@ -43,7 +43,6 @@
         </div>
 
         <div class="col-sm-8 no-pad-mobile">
-
             {% if legislation.board_report %}
 	    {% with board_report=legislation.board_report %}
                 <h3>
@@ -73,8 +72,7 @@
                     frameborder="0"
                     seamless="true"
                     width="100%"
-                    height="600px"
-                    src="/pdfviewer/?{{board_report.url|full_text_doc_url}}">
+                    height="600px">
                 </iframe>
 
                 <div class="divider"></div>
@@ -289,11 +287,11 @@
             }
         });
 
-        if (window.screen.width > 768){
-            $("#pdf-embed").attr("src", "/pdfviewer/?{{legislation.url|full_text_doc_url}}");
+        if (window.innerWidth > 768){
+            $("#pdf-embed-agenda").attr("src", "/pdfviewer/?{{legislation.board_report.url|full_text_doc_url}}");
         }
         else{
-            $('#pdf-embed').hide()
+            $('#pdf-embed-agenda').hide()
             $('#pdf-download-link').html("<i class='fa fa-fw fa-external-link'></i> View PDF")
         }
 


### PR DESCRIPTION
## Overview

This PR:

- Fixes a bug in the board report detail page JavaScript that returns the wrong (i.e., empty) full text doc URL
- Updates the screen size check to use `innerWidth` rather than screen width, as `innerWidth` reflects available window size, which is not always the entire screen
- Adds the screen size check to the event agenda viewer

Connects #1149 

### Notes

The screen size check is meant to prevent agenda documents from loading on mobile devices in order to reduce bandwidth required to view the site on mobile. The current implementation, however, does not achieve this intent, because it renders the PDF viewer, then hides it via CSS. This update will prevent PDFs from loading at all on small screens, potentially connecting it to #1138. 

## Testing Instructions

 * View some event and board report detail pages and confirm the PDF viewer works as intended.
 * Repeat step one on a smaller screen and confirm the PDF viewer is not shown.
 * Manually upload an event agenda via URL and document upload, and confirm the PDF is shown correctly.
