### PR TITLE
Don't load all events on default events page

### DIFF
--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -102,6 +102,7 @@ ADV_CACHE_INCLUDE_PK = True
 DEBUG_TOOLBAR_PANELS = [
     "debug_toolbar.panels.sql.SQLPanel",
     "debug_toolbar.panels.cache.CachePanel",
+    "template_profiler_panel.panels.template.TemplateProfilerPanel",
 ]
 
 
@@ -121,6 +122,7 @@ INSTALLED_APPS = (
     "councilmatic_core",
     "adv_cache_tag",
     "debug_toolbar",
+    "template_profiler_panel",
     "captcha",
     "markdownify.apps.MarkdownifyConfig",
 )

--- a/lametro/templates/events/events.html
+++ b/lametro/templates/events/events.html
@@ -79,7 +79,7 @@
 								{% if 'show' in request.GET and request.GET.show == 'future' %}
 									<a href="{% url 'events' %}" class="btn btn-salmon" id="fewer-upcoming-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer upcoming meetings</a>
 								{% else %}
-									<a href="{% url 'events' %}?show=future#future-meetings" class="btn btn-salmon" id="more-upcoming-events"><i class="fa fa-fw fa-chevron-down"></i>Show all upcoming meetings</a>
+									<a href="{% url 'events' %}?show=future#upcoming-meetings" class="btn btn-salmon" id="more-upcoming-events"><i class="fa fa-fw fa-chevron-down"></i>Show all upcoming meetings</a>
 								{% endif %}
 
                 <h2 id="past-meetings" style="margin-top: 40px;"><span>Past {{ CITY_VOCAB.EVENTS }}</span>

--- a/lametro/templates/events/events.html
+++ b/lametro/templates/events/events.html
@@ -50,7 +50,7 @@
             {% endif %}
 
             {% if future_events %}
-                <h2><span>Upcoming {{ CITY_VOCAB.EVENTS }}</span>
+                <h2 id="upcoming-meetings"><span>Upcoming {{ CITY_VOCAB.EVENTS }}</span>
                 <br class="non-desktop-only"/>
                 <small>
                     <a href="rss/" title="RSS feed for Upcoming and Recent Events">
@@ -76,10 +76,13 @@
                     </div>
                 {% endfor %}
 
-                <a href="" class="btn btn-salmon" id="more-upcoming-events"><i class="fa fa-fw fa-chevron-down"></i>Show all upcoming meetings</a>
-                <a href="" class="btn btn-salmon" id="fewer-upcoming-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer upcoming meetings</a>
+								{% if 'show' in request.GET and request.GET.show == 'future' %}
+									<a href="{% url 'events' %}" class="btn btn-salmon" id="fewer-upcoming-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer upcoming meetings</a>
+								{% else %}
+									<a href="{% url 'events' %}?show=future#future-meetings" class="btn btn-salmon" id="more-upcoming-events"><i class="fa fa-fw fa-chevron-down"></i>Show all upcoming meetings</a>
+								{% endif %}
 
-                <h2 style="margin-top: 40px;"><span>Past {{ CITY_VOCAB.EVENTS }}</span>
+                <h2 id="past-meetings" style="margin-top: 40px;"><span>Past {{ CITY_VOCAB.EVENTS }}</span>
                 <br class="non-desktop-only"/>
                 <small><a href="rss/" title="RSS feed for Upcoming and Recent Events"><i class="fa fa-rss-square" aria-hidden="true"></i></a></small>
                 </h2><br class="non-mobile-only"/>
@@ -94,8 +97,11 @@
                     </div>
                 {% endfor %}
 
-                <a href="" class="btn btn-salmon" id="more-events"><i class="fa fa-fw fa-chevron-down"></i>Show all past meetings</a>
-                <a href="" class="btn btn-salmon" id="fewer-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer past meetings</a>
+								{% if 'show' in request.GET and request.GET.show == 'past' %}
+									<a href="{% url 'events' %}" class="btn btn-salmon" id="fewer-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer past meetings</a>
+								{% else %}
+									<a href="{% url 'events' %}?show=past#past-meetings" class="btn btn-salmon" id="more-events"><i class="fa fa-fw fa-chevron-down"></i>Show all past meetings</a>
+								{% endif %}
 
             {% elif past_events %}
                 <h2 style="margin-top: 40px;"><span>Past {{ CITY_VOCAB.EVENTS }}</span>
@@ -115,6 +121,7 @@
 
                 <a href="" class="btn btn-salmon" id="more-events"><i class="fa fa-fw fa-chevron-down"></i>Show all past meetings</a>
                 <a href="" class="btn btn-salmon" id="fewer-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer past meetings</a>
+
             {% elif select_events %}
                 <h2><span>{{ CITY_VOCAB.EVENTS }} from {{ start_date }} to {{ end_date }}</span>
                 <br class="non-desktop-only"/>
@@ -174,53 +181,8 @@
     <script type="{% static 'js/lib/bootstrap-datetimepicker.js' %}"></script>
     <script>
     $(document).ready(function() {
-
         $('#from').datepicker();
         $('#to').datepicker();
-
-        function collapseUpcomingEvents(){
-            $(".event-upcoming-listing:gt(2)").hide();
-            $("#more-upcoming-events").show();
-            $("#fewer-upcoming-events").hide();
-        }
-        function expandUpcomingEvents(){
-            $(".event-upcoming-listing:gt(2)").show();
-            $("#more-upcoming-events").hide();
-            $("#fewer-upcoming-events").show();
-        }
-        function collapseEvents(){
-            $(".event-listing:gt(4)").hide();
-            $("#more-events").show();
-            $("#fewer-events").hide();
-        }
-        function expandEvents(){
-            $(".event-listing:gt(4)").show();
-            $("#more-events").hide();
-            $("#fewer-events").show();
-        }
-
-        collapseEvents();
-        collapseUpcomingEvents();
-
-        $("#more-upcoming-events").click(function() {
-            expandUpcomingEvents();
-            return false;
-        });
-
-        $("#fewer-upcoming-events").click(function() {
-            collapseUpcomingEvents();
-            return false;
-        });
-
-        $("#more-events").click(function() {
-            expandEvents();
-            return false;
-        });
-
-        $("#fewer-events").click(function() {
-            collapseEvents();
-            return false;
-        });
     });
     </script>
 {% endblock %}

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -1,7 +1,5 @@
-from operator import attrgetter
 import itertools
 import urllib
-from datetime import date, datetime
 from dateutil import parser
 import requests
 import os

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -1,5 +1,6 @@
 import itertools
 import urllib
+from datetime import datetime
 from dateutil import parser
 import requests
 import os

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -391,13 +391,8 @@ class LAMetroEventsView(EventsView):
             context["all_events"] = [(d, list(events)) for d, events in org_all_events]
 
         else:
-            past_events = (
-                media_events.filter(start_time__lt=timezone.now())
-                .prefetch_related(
-                    Prefetch("documents", minutes_queryset, to_attr="minutes")
-                )
-                .prefetch_related("minutes__links")
-                .order_by("-start_time")
+            past_events = media_events.filter(start_time__lt=timezone.now()).order_by(
+                "-start_time"
             )
             future_events = media_events.filter(start_time__gt=timezone.now()).order_by(
                 "start_time"
@@ -428,6 +423,11 @@ class LAMetroEventsView(EventsView):
                 future_events = media_events.filter(
                     start_time__date__in=next_three_meeting_days
                 ).order_by("start_time")
+
+            # Prefetch documents for past events
+            past_events = past_events.prefetch_related(
+                Prefetch("documents", minutes_queryset, to_attr="minutes")
+            ).prefetch_related("minutes__links")
 
             # Group meetings by day
             org_future_events = itertools.groupby(future_events, key=day_grouper)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ django-markdownify==0.9.3
 
 # Development
 django-debug-toolbar
+django-debug-toolbar-template-profiler
 pytest
 pytest-django
 pytest-mock==1.6.3


### PR DESCRIPTION
## Overview

Previously, `LAMetroEventsView` was iterating over and then serializing all events, both past and future, each time the page was loaded. The template simply truncated the events listing. I believe part of the high load times on the events page was caused by serializing so many events for each request.

This PR aims to reduce the load time of the main events page by only computing and serializing three days of events by default. The user can then request to view all future or past meetings.

Connects #1138 

## Benchmarks

I added a [template profiler](https://github.com/node13h/django-debug-toolbar-template-profiler) to Django Debug Toolbar to be able to benchmark template load times locally.

This PR reduced template load time on the default events page to ~40ms from ~475ms (-91%). Of course, showing all events will always greatly increase load time. But even that is faster now that we're only serializing either all past or future events instead of both.

### Notes

The inclusion of both future and past events on the same page leads to a little quirkiness in the code and a less than ideal UX. I think we could simplify things and lean more on Django's built-in `Paginator` in `ListView`s by separating out the future and past event listings. 

The default events page could stay the same. But the "Show upcoming meetings" button, for example, could lead to a separate page with pagination. This would also avoid ever having to serialize thousands of events in one request.

## Testing Instructions
 * Verify that the date picker on the events page still functions
 * Verify that clicking the show upcoming/past meetings buttons work as expected
