### PR TITLE
Optimize event detail page

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -542,31 +542,6 @@ class LAMetroEventManager(EventManager):
             Prefetch("media", queryset=mediaqueryset)
         ).prefetch_related("media__links")
 
-    def with_related_bills(self):
-        latest_action = BillAction.objects.filter(bill=OuterRef("pk")).order_by(
-            "-order"
-        )
-
-        related_bills = (
-            LAMetroBill.objects.filter(eventrelatedentity__agenda_item__event=event)
-            .defer("extras")
-            .prefetch_related(
-                Prefetch(
-                    "versions",
-                    queryset=BillVersion.objects.filter(
-                        note="Board Report"
-                    ).prefetch_related("links"),
-                    to_attr="br",
-                ),
-                "packet",
-            )
-            .annotate(
-                last_action_description=Subquery(
-                    latest_action.values("description")[:1]
-                )
-            )
-        )
-
 
 class LiveMediaMixin(object):
     BASE_MEDIA_URL = "http://metro.granicus.com/mediaplayer.php?"

--- a/lametro/templates/event/_related_bills.html
+++ b/lametro/templates/event/_related_bills.html
@@ -14,11 +14,11 @@
       {% with associated_bill=report.related_entities.all.0.bill %}
       <tr>
         <td><strong>{{ report.notes.0 | parse_agenda_item }}</strong></td>
-        <td>{{associated_bill.identifier}} {{report.description | short_blurb}} {{ associated_bill.inferred_status | inferred_status_label | safe }}</td>
+        <td>{{associated_bill.identifier}} {{report.description | short_blurb}} {{ associated_bill.last_action_description | bill_status_from_last_action | inferred_status_label | safe }}</td>
         <td>
           <a href='/board-report/{{ associated_bill.slug }}/' target="_blank">View</a>
         </td>
-        <td><a href={% if associated_bill.packet.is_ready %}"{{associated_bill.packet.url}}"{% else %}"{{associated_bill.board_report.url}}"{% endif %}>Download</a></td>
+        <td><a href={% if associated_bill.packet.is_ready %}"{{associated_bill.packet.url}}"{% else %}"{{associated_bill.br.url}}"{% endif %}>Download</a></td>
       </tr>
       {% endwith %}
   {% endfor %}

--- a/lametro/templates/event/_related_bills.html
+++ b/lametro/templates/event/_related_bills.html
@@ -18,7 +18,7 @@
         <td>
           <a href='/board-report/{{ associated_bill.slug }}/' target="_blank">View</a>
         </td>
-        <td><a href={% if associated_bill.packet.is_ready %}"{{associated_bill.packet.url}}"{% else %}"{{associated_bill.br.url}}"{% endif %}>Download</a></td>
+        <td><a href={% if associated_bill.packet.is_ready %}"{{associated_bill.packet.url}}"{% else %}"{{associated_bill.br.0.links.all.0.url}}"{% endif %}>Download</a></td>
       </tr>
       {% endwith %}
   {% endfor %}

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -7,7 +7,10 @@ import urllib
 from django import template
 from django.utils import timezone
 
-from councilmatic.settings_jurisdiction import legislation_types
+from councilmatic.settings_jurisdiction import (
+    legislation_types,
+    BILL_STATUS_DESCRIPTIONS,
+)
 from councilmatic.settings import PIC_BASE_URL
 from councilmatic_core.models import Person, Bill
 
@@ -327,3 +330,10 @@ def get_events_with_manual_broadcasts():
     broadcasts = EventBroadcast.objects.filter(is_manually_live=True)
     events = [b.event for b in broadcasts]
     return events
+
+
+@register.filter
+def bill_status_from_last_action(description):
+    if description and description.upper() in BILL_STATUS_DESCRIPTIONS.keys():
+        return BILL_STATUS_DESCRIPTIONS[description.upper()]["search_term"]
+    return None

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -26,8 +26,6 @@ from django.db.models import (
     IntegerField,
     Q,
     F,
-    OuterRef,
-    Subquery,
 )
 from django.urls import reverse
 from django.utils import timezone
@@ -62,7 +60,7 @@ from councilmatic_core.views import (
 from councilmatic_core.models import Organization, Membership
 
 from opencivicdata.core.models import PersonLink
-from opencivicdata.legislative.models import BillVersion, BillAction
+from opencivicdata.legislative.models import BillVersion
 
 from lametro.models import (
     LAMetroBill,

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -26,8 +26,6 @@ from django.db.models import (
     IntegerField,
     Q,
     F,
-    OuterRef,
-    Subquery,
 )
 from django.urls import reverse
 from django.utils import timezone
@@ -63,8 +61,6 @@ from councilmatic_core.models import Organization, Membership
 
 from opencivicdata.core.models import PersonLink
 from opencivicdata.legislative.models import (
-    Bill,
-    BillVersion,
     BillAction,
     EventRelatedEntity,
 )

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -221,13 +221,10 @@ class LAMetroEventDetail(EventDetailView):
         except EventDocument.DoesNotExist:
             pass
 
-        latest_action = BillAction.objects.filter(bill=OuterRef("pk")).order_by(
-            "-order"
-        )
-
         related_bills = (
-            LAMetroBill.objects.filter(eventrelatedentity__agenda_item__event=event)
+            LAMetroBill.objects.with_latest_actions()
             .defer("extras")
+            .filter(eventrelatedentity__agenda_item__event=event)
             .prefetch_related(
                 Prefetch(
                     "versions",
@@ -237,11 +234,6 @@ class LAMetroEventDetail(EventDetailView):
                     to_attr="br",
                 ),
                 "packet",
-            )
-            .annotate(
-                last_action_description=Subquery(
-                    latest_action.values("description")[:1]
-                )
             )
         )
 


### PR DESCRIPTION
## Overview

This PR reduces redundant database calls on the event detail page. Locally, I see a 30% faster load time but I suspect it might be different on staging.

Connects #1138 

## Testing Instructions

* Verify that the event detail page functions as expected, especially the agenda item list
* Verify that agenda item links (View/Download) are correct
