### PR TITLE
Cache external requests

### DIFF
--- a/lametro/utils.py
+++ b/lametro/utils.py
@@ -131,15 +131,13 @@ def timed_get(
     if cached_resp:
         return cached_resp
 
-    TOTAL_TIMEOUT = kwargs.get("timeout", settings.REQUEST_TIMEOUT)
-
     def trace_function(frame, event, arg):
         """
         Makes sure our request raises an exception if the total time from
         start to finish exceeds TOTAL_TIMEOUT.
         """
-        if time.time() - start > TOTAL_TIMEOUT:
-            raise LAMetroRequestTimeoutException(url, TOTAL_TIMEOUT)
+        if time.time() - start > timeout:
+            raise LAMetroRequestTimeoutException(url, timeout)
 
         return trace_function
 

--- a/lametro/utils.py
+++ b/lametro/utils.py
@@ -7,6 +7,7 @@ import sys
 import time
 
 from django.conf import settings
+from django.core.cache import cache
 
 from haystack.utils.highlighting import Highlighter
 
@@ -116,12 +117,19 @@ class LAMetroRequestTimeoutException(Exception):
         super().__init__(f"Request to {url} took longer than {timeout} seconds.")
 
 
-def timed_get(url, params=None, **kwargs):
+def timed_get(
+    url, params=None, timeout=settings.REQUEST_TIMEOUT, cache_for=60, **kwargs
+):
     """
     Convenience function to ensure GET requests that time out raise an exception.
 
     See https://stackoverflow.com/a/71453648
     """
+
+    # Check the Django cache
+    cached_resp = cache.get(url)
+    if cached_resp:
+        return cached_resp
 
     TOTAL_TIMEOUT = kwargs.get("timeout", settings.REQUEST_TIMEOUT)
 
@@ -143,5 +151,9 @@ def timed_get(url, params=None, **kwargs):
         raise e
     finally:
         sys.settrace(None)
+
+    # Cache the response
+    if cache_for and cache_for > 0:
+        cache.set(url, resp, cache_for)
 
     return resp


### PR DESCRIPTION
## Overview

This PR adds caching to the `timed_get` function. This allows for easier, sort-of built in caching of external requests to Granicus.

Connects #1162 

## Testing Instructions
* Verify that the homepage and event detail pages function as expected
* I'll also wait until a meeting day to verify functionality
