### PR TITLE
Migrate usage of wagtail modeladmin to snippets

### DIFF
--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -148,7 +148,6 @@ INSTALLED_APPS = (
     "wagtail.images",
     "wagtail.search",
     "wagtail.admin",
-    "wagtail.contrib.modeladmin",
     "wagtail",
     "modelcluster",
     "taggit",

--- a/lametro/models/cms.py
+++ b/lametro/models/cms.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django import forms
 from django.utils.html import format_html, strip_tags
 from django.contrib.postgres.fields import ArrayField
+from html import unescape
 
 from wagtail.models import Page, PreviewableMixin, DraftStateMixin, RevisionMixin
 from wagtail.fields import StreamField, RichTextField
@@ -197,3 +198,20 @@ class EventNotice(models.Model):
         ),
         FieldPanel("message"),
     ]
+
+    def get_message(self):
+        return strip_tags(unescape(self.message))[:50]
+
+    def get_comment_conditions(self):
+        return self.format_conditions(self.comment_conditions)
+
+    def get_broadcast_conditions(self):
+        return self.format_conditions(self.broadcast_conditions)
+
+    def format_conditions(self, conditions):
+        formatted_conditions = [cond.replace("_", " ") for cond in conditions]
+        return " | ".join(formatted_conditions)
+
+    get_message.short_description = "Message"
+    get_comment_conditions.short_description = "Comment conditions"
+    get_broadcast_conditions.short_description = "Broadcast conditions"

--- a/lametro/models/cms.py
+++ b/lametro/models/cms.py
@@ -203,7 +203,20 @@ class EventNotice(models.Model):
         return strip_tags(unescape(self.message))[:50]
 
     def get_comment_conditions(self):
-        return self.format_conditions(self.comment_conditions)
+        """
+        Display the longer version of the condition choices
+        in the listing view for clarity
+        """
+        long_conditions = []
+        for cond in self.comment_conditions:
+            long_conditions.extend(
+                [
+                    choice[1]
+                    for choice in self.COMMENT_CONDITION_CHOICES
+                    if choice[0] == cond
+                ]
+            )
+        return self.format_conditions(long_conditions)
 
     def get_broadcast_conditions(self):
         return self.format_conditions(self.broadcast_conditions)


### PR DESCRIPTION
## Overview

This migrates usage of wagtail's modeladmin module throughout the app, to the newer snippets module. This also refines the filters used in the event notice listing page.

- Closes #1177

### Demo

![image](https://github.com/user-attachments/assets/c811381f-952c-403e-8df7-35368d830596)

### Notes

~~This is comparing to (and branched from) the board-member-details cms branch since that had a start to this migration. I can change the comparison to the cms/epic branch after the board member one gets merged.~~ Base branch changed!

## Testing Instructions
 * Log in to the cms and make an event notice
 * Confirm that the notice gets created as expected
 * Confirm that filtering notices on the list view works as expected
