### PR TITLE
Fix upcoming meeting agenda pdf link

### DIFF
--- a/lametro/templates/index/_meeting_details_next.html
+++ b/lametro/templates/index/_meeting_details_next.html
@@ -34,20 +34,19 @@
         </p>
 
         <!-- Supplementary links -->
-        {% if meeting.documents.all %}
-          <div class="row">
-            <div class="col-7">
-              {% with agenda_url=meeting.documents.all|find_agenda_url %}
-                {% if agenda_url %}
-                  <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{ agenda_url }}' aria-label="Get Agenda PDF - link opens in a new tab">
-                    <i class='fa fa-fw fa-download' aria-hidden="true"></i>
-                    Get Agenda PDF
-                  </a>
-                {% endif %}
-              {% endwith %}
+        {% with agenda_url=meeting.documents.all|find_agenda_url %}
+          {% if agenda_url %}
+            <div class="row">
+              <div class="col-7">
+                <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{ agenda_url }}' aria-label="Get Agenda PDF - link opens in a new tab">
+                  <i class='fa fa-fw fa-download' aria-hidden="true"></i>
+                  Get Agenda PDF
+                </a>
+              </div>
             </div>
-          </div>
-        {% endif %}
+          {% endif %}
+        {% endwith %}
+
       </div>
       {% endfor %}
     </div>

--- a/lametro/templates/index/_meeting_details_next.html
+++ b/lametro/templates/index/_meeting_details_next.html
@@ -37,10 +37,14 @@
         {% if meeting.documents.all %}
           <div class="row">
             <div class="col-7">
-              <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='#' aria-label="Get Agenda PDF - link opens in a new tab">
-                <i class='fa fa-fw fa-download' aria-hidden="true"></i>
-                Get Agenda PDF
-              </a>
+              {% with agenda_url=meeting.documents.all|find_agenda_url %}
+                {% if agenda_url %}
+                  <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{ agenda_url }}' aria-label="Get Agenda PDF - link opens in a new tab">
+                    <i class='fa fa-fw fa-download' aria-hidden="true"></i>
+                    Get Agenda PDF
+                  </a>
+                {% endif %}
+              {% endwith %}
             </div>
           </div>
         {% endif %}

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -190,7 +190,12 @@ def find_agenda_url(all_documents):
 
     valid_urls += pdf_url
 
-    return valid_urls[0]
+    try:
+        agenda_url = valid_urls[0]
+    except IndexError:
+        agenda_url = None
+
+    return agenda_url
 
 
 @register.simple_tag(takes_context=True)


### PR DESCRIPTION
## Overview

This PR fixes the links to agenda PDF for upcoming meetings. It looks like the links in the template were somehow overwritten during the bootstrap upgrade.

I also added some a few extra lines to `find_agenda_url` to make sure the whole page doesn't throw an error if for some reason an agenda link couldn't be found.

Connects #1217

### Demo

<img width="703" alt="Screenshot 2025-02-24 at 3 40 24 PM" src="https://github.com/user-attachments/assets/9699abe7-8e61-4176-aa02-742a9691aa64" />


## Testing Instructions

 * Verify that the link for the upcoming meeting works as expected
