### PR TITLE
Handle non-event views in EventAgendaLink

### DIFF
--- a/lametro/wagtail_hooks.py
+++ b/lametro/wagtail_hooks.py
@@ -413,7 +413,10 @@ class EventAgendaLink(UserBarLink):
         except KeyError:
             return
 
-        event = LAMetroEvent.objects.get(slug=slug)
+        try:
+            event = LAMetroEvent.objects.get(slug=slug)
+        except LAMetroEvent.DoesNotExist:
+            return
 
         if (
             not event.documents.exclude(note__icontains="manual")


### PR DESCRIPTION
## Overview

This PR addresses a bug introduced by #1220 which prevented any detail pages besides event detail pages from loading.

Connects #1238 

## Testing Instructions

* Visit event, person, and board report detail pages and confirm they render without error.