### PR TITLE
Ensure test meetings are not shown on index

### DIFF
--- a/lametro/models/legislative.py
+++ b/lametro/models/legislative.py
@@ -769,7 +769,9 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
 
         Otherwise, return an empty queryset.
         """
-        scheduled_meetings = cls._potentially_current_meetings()
+        scheduled_meetings = cls._potentially_current_meetings().exclude(
+            name__icontains="test"
+        )
 
         if scheduled_meetings:
             streaming_meeting = cls._streaming_meeting()
@@ -929,9 +931,11 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
         today_utc = today_la.astimezone(pytz.utc)
         tomorrow_utc = today_utc + timedelta(days=1)
 
-        return cls.objects.filter(
-            start_time__gte=today_utc, start_time__lt=tomorrow_utc
-        ).prefetch_related("broadcast", "location")
+        return (
+            cls.objects.filter(start_time__gte=today_utc, start_time__lt=tomorrow_utc)
+            .exclude(name__icontains="test")
+            .prefetch_related("broadcast", "location")
+        )
 
     @property
     def display_status(self):


### PR DESCRIPTION
## Overview

Quick change to exclude test meetings from a couple of model methods. This can be tested on the review app as is.
 
- Connects #1240

### Demo

Before:
<img width="1265" alt="image" src="https://github.com/user-attachments/assets/6ecaf671-a31b-4c4b-b059-7f005aa3052f" />

---

After:
<img width="1258" alt="image" src="https://github.com/user-attachments/assets/8f941d80-2928-4875-b074-6c4af1795ea4" />

## Testing Instructions
 * Head to the review app
 * Confirm that there are no test meetings showing under today's meeting, or the current meeting
